### PR TITLE
Rewrite dicts like .chunks and .sizes

### DIFF
--- a/cf_xarray/accessor.py
+++ b/cf_xarray/accessor.py
@@ -323,8 +323,10 @@ def _getattr(
             return dict(attribute)
         # attributes like chunks / sizes
         newmap = dict()
+        unused_keys = set(attribute.keys())
         for key in _AXIS_NAMES + _COORD_NAMES:
             value = _get_axis_coord(obj, key, error=False, default=None)
+            unused_keys -= set(value)
             if value != [None]:
                 good_values = set(value) & set(obj.dims)
                 if not good_values:
@@ -335,6 +337,7 @@ def _getattr(
                         f"There is no unique mapping from {key!r} to a value in {attr!r}."
                     )
                 newmap.update({key: attribute[good_values.pop()]})
+        newmap.update({key: attribute[key] for key in unused_keys})
         return newmap
 
     elif isinstance(attribute, Callable):  # type: ignore

--- a/cf_xarray/accessor.py
+++ b/cf_xarray/accessor.py
@@ -365,7 +365,7 @@ def _getattr(
                     continue
                 if len(good_values) > 1:
                     raise AttributeError(
-                        f"cf_array can't wrap attribute {attr!r} because there are multiple values for {key!r} viz. {good_values!r}. "
+                        f"cf_xarray can't wrap attribute {attr!r} because there are multiple values for {key!r} viz. {good_values!r}. "
                         f"There is no unique mapping from {key!r} to a value in {attr!r}."
                     )
                 newmap.update({key: attribute[good_values.pop()]})

--- a/cf_xarray/accessor.py
+++ b/cf_xarray/accessor.py
@@ -316,7 +316,35 @@ def _getattr(
         An extra decorator, if necessary. This is used by _CFPlotMethods to set default
         kwargs based on CF attributes.
     """
-    func: Callable = getattr(obj, attr)
+    attribute: Union[Mapping, Callable] = getattr(obj, attr)
+
+    if isinstance(attribute, Mapping):
+        if not attribute:
+            return dict(attribute)
+        # attributes like chunks / sizes
+        newmap = dict()
+        for key in _AXIS_NAMES + _COORD_NAMES:
+            value = _get_axis_coord(obj, key, error=False, default=None)
+            if value != [None]:
+                good_values = set(value) & set(obj.dims)
+                if not good_values:
+                    continue
+                if len(good_values) > 1:
+                    raise AttributeError(
+                        f"cf_array can't wrap attribute {attr!r} because there are multiple values for {key!r} viz. {good_values!r}. "
+                        f"There is no unique mapping from {key!r} to a value in {attr!r}."
+                    )
+                newmap.update({key: attribute[good_values.pop()]})
+        return newmap
+
+    elif isinstance(attribute, Callable):  # type: ignore
+        func: Callable = attribute
+
+    else:
+        raise AttributeError(
+            f"cf_xarray does not know how to wrap attribute '{type(obj).__name__}.{attr}'. "
+            "Please file an issue if you have a solution."
+        )
 
     @functools.wraps(func)
     def wrapper(*args, **kwargs):

--- a/cf_xarray/tests/datasets.py
+++ b/cf_xarray/tests/datasets.py
@@ -70,3 +70,13 @@ anc["q_detection_limit"] = xr.DataArray(
     1e-3, attrs=dict(standard_name="specific_humidity detection_minimum", units="g/g"),
 )
 anc
+
+
+multiple = xr.Dataset()
+multiple.coords["x1"] = ("x1", range(30), {"axis": "X"})
+multiple.coords["y1"] = ("y1", range(20), {"axis": "Y"})
+multiple.coords["x2"] = ("x2", range(10), {"axis": "X"})
+multiple.coords["y2"] = ("y2", range(5), {"axis": "Y"})
+
+multiple["v1"] = (("x1", "y1"), np.ones((30, 20)) * 15)
+multiple["v2"] = (("x2", "y2"), np.ones((10, 5)) * 15)

--- a/cf_xarray/tests/test_accessor.py
+++ b/cf_xarray/tests/test_accessor.py
@@ -8,7 +8,7 @@ from xarray.testing import assert_identical
 import cf_xarray  # noqa
 
 from . import raise_if_dask_computes
-from .datasets import airds, anc, ds_no_attrs, popds
+from .datasets import airds, anc, ds_no_attrs, multiple, popds
 
 mpl.use("Agg")
 
@@ -260,3 +260,29 @@ def test_plot_xincrease_yincrease():
 
     for lim in [ax.get_xlim(), ax.get_ylim()]:
         assert lim[0] > lim[1]
+
+
+def test_dicts():
+    actual = ds.cf.sizes
+    expected = {"X": 50, "Y": 25, "T": 4, "longitude": 50, "latitude": 25, "time": 4}
+    assert actual == expected
+
+    assert popds.cf.sizes == {}
+
+    with pytest.raises(AttributeError):
+        multiple.cf.sizes
+
+    assert airds.cf.chunks == {}
+
+    expected = {
+        "X": (50,),
+        "Y": (5, 5, 5, 5, 5),
+        "T": (4,),
+        "longitude": (50,),
+        "latitude": (5, 5, 5, 5, 5),
+        "time": (4,),
+    }
+    assert airds.chunk({"lat": 5}).cf.chunks == expected
+
+    with pytest.raises(AttributeError):
+        airds.da.cf.chunks

--- a/cf_xarray/tests/test_accessor.py
+++ b/cf_xarray/tests/test_accessor.py
@@ -18,6 +18,40 @@ dataarrays = [airds.air, airds.air.chunk({"lat": 5})]
 objects = datasets + dataarrays
 
 
+def test_dicts():
+    from .datasets import airds
+
+    actual = airds.cf.sizes
+    expected = {"X": 50, "Y": 25, "T": 4, "longitude": 50, "latitude": 25, "time": 4}
+    assert actual == expected
+
+    assert popds.cf.sizes == popds.sizes
+
+    with pytest.raises(AttributeError):
+        multiple.cf.sizes
+
+    assert airds.cf.chunks == {}
+
+    expected = {
+        "X": (50,),
+        "Y": (5, 5, 5, 5, 5),
+        "T": (4,),
+        "longitude": (50,),
+        "latitude": (5, 5, 5, 5, 5),
+        "time": (4,),
+    }
+    assert airds.chunk({"lat": 5}).cf.chunks == expected
+
+    with pytest.raises(AttributeError):
+        airds.da.cf.chunks
+
+    airds = airds.copy(deep=True)
+    airds.lon.attrs = {}
+    actual = airds.cf.sizes
+    expected = {"lon": 50, "Y": 25, "T": 4, "latitude": 25, "time": 4}
+    assert actual == expected
+
+
 def test_describe():
     actual = airds.cf._describe()
     expected = (
@@ -260,29 +294,3 @@ def test_plot_xincrease_yincrease():
 
     for lim in [ax.get_xlim(), ax.get_ylim()]:
         assert lim[0] > lim[1]
-
-
-def test_dicts():
-    actual = ds.cf.sizes
-    expected = {"X": 50, "Y": 25, "T": 4, "longitude": 50, "latitude": 25, "time": 4}
-    assert actual == expected
-
-    assert popds.cf.sizes == {}
-
-    with pytest.raises(AttributeError):
-        multiple.cf.sizes
-
-    assert airds.cf.chunks == {}
-
-    expected = {
-        "X": (50,),
-        "Y": (5, 5, 5, 5, 5),
-        "T": (4,),
-        "longitude": (50,),
-        "latitude": (5, 5, 5, 5, 5),
-        "time": (4,),
-    }
-    assert airds.chunk({"lat": 5}).cf.chunks == expected
-
-    with pytest.raises(AttributeError):
-        airds.da.cf.chunks

--- a/doc/examples/introduction.ipynb
+++ b/doc/examples/introduction.ipynb
@@ -415,6 +415,58 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Feature: Rewriting property dictionaries\n",
+    "\n",
+    "`cf_xarray` will rewrite the `.sizes` and `.chunks` dictionaries so that one can index by a special CF axis or coordinate name"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds.cf.sizes"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note the duplicate entries above:\n",
+    "\n",
+    "1. One for `X`, `Y`, `T`\n",
+    "2. and one for `longitude`, `latitude` and `time`.\n",
+    "\n",
+    "An error is raised if there are multiple `'X'` variables (for example)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "raises-exception"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "multiple.cf.sizes"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "multiple.v1.cf.sizes"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Feature: Rewriting arguments\n",
     "\n",
     "`cf_xarray` can rewrite arguments for a large number of xarray functions. By this I mean that instead of specifing say `dim=\"lon\"`, you can pass `dim=\"X\"` or `dim=\"longitude\"` and `cf_xarray` will rewrite that to `dim=\"lon\"` based on the attributes present in the dataset. \n",
@@ -637,9 +689,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### miscellaneous features\n",
-    "\n",
-    "You can mix \"special names\" and variable names"
+    "## Feature: mix \"special names\" and variable names"
    ]
   },
   {


### PR DESCRIPTION
This makes it so that

``` python
>>> ds.cf.sizes
{'X': 53, 'Y': 25, 'T': 2920, 'longitude': 53, 'latitude': 25, 'time': 2920}
```

An error is raised for Datasets with multiple `X` variables
``` python
AttributeError: cf_xarray can't wrap attribute 'sizes' because there are multiple values for 'X' viz. {'x1', 'x2'}. There is no unique mapping from 'X' to a value in 'sizes'.
```