### PR TITLE
Add .cf.add_bounds to guess bounds for 1D coord.

### DIFF
--- a/cf_xarray/tests/test_accessor.py
+++ b/cf_xarray/tests/test_accessor.py
@@ -1,8 +1,9 @@
 import matplotlib as mpl
+import numpy as np
 import pytest
 import xarray as xr
 from matplotlib import pyplot as plt
-from xarray.testing import assert_identical
+from xarray.testing import assert_allclose, assert_identical
 
 import cf_xarray  # noqa
 
@@ -287,3 +288,19 @@ def test_plot_xincrease_yincrease():
 
     for lim in [ax.get_xlim(), ax.get_ylim()]:
         assert lim[0] > lim[1]
+
+
+@pytest.mark.parametrize("obj", [airds, airds.air])
+def test_add_bounds(obj):
+    added = obj.cf.add_bounds("lat")
+    assert "lat_bounds" in added.coords
+    assert added.lat.attrs["bounds"] == "lat_bounds"
+    expected = xr.concat(
+        [
+            obj.lat.copy(data=np.arange(76.25, 16.0, -2.5)),
+            obj.lat.copy(data=np.arange(73.75, 13.6, -2.5)),
+        ],
+        dim="bounds",
+    )
+    expected.attrs.clear()
+    assert_allclose(added.lat_bounds.reset_coords(drop=True), expected)

--- a/cf_xarray/tests/test_accessor.py
+++ b/cf_xarray/tests/test_accessor.py
@@ -1,5 +1,6 @@
 import matplotlib as mpl
 import numpy as np
+import pandas as pd
 import pytest
 import xarray as xr
 from matplotlib import pyplot as plt
@@ -290,7 +291,7 @@ def test_plot_xincrease_yincrease():
         assert lim[0] > lim[1]
 
 
-@pytest.mark.parametrize("dims", ["lat", ["lat", "lon"]])
+@pytest.mark.parametrize("dims", ["lat", "time", ["lat", "lon"]])
 @pytest.mark.parametrize("obj", [airds, airds.air])
 def test_add_bounds(obj, dims):
     expected = dict()
@@ -308,8 +309,20 @@ def test_add_bounds(obj, dims):
         ],
         dim="bounds",
     )
+    t0 = pd.Timestamp("2013-01-01")
+    t1 = pd.Timestamp("2013-01-01 18:00")
+    dt = "6h"
+    dtb2 = pd.Timedelta("3h")
+    expected["time"] = xr.concat(
+        [
+            obj.time.copy(data=pd.date_range(start=t0 - dtb2, end=t1 - dtb2, freq=dt)),
+            obj.time.copy(data=pd.date_range(start=t0 + dtb2, end=t1 + dtb2, freq=dt)),
+        ],
+        dim="bounds",
+    )
     expected["lat"].attrs.clear()
     expected["lon"].attrs.clear()
+    expected["time"].attrs.clear()
 
     added = obj.cf.add_bounds(dims)
     if isinstance(dims, str):

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -1,6 +1,11 @@
 What's New
 ----------
 
+v0.1.6
+======
+
+- Added ```.cf.add_bounds`` to add guessed bounds for 1D coorindates. (:pr:`53`) `Deepak Cherian`_.
+
 v0.1.5
 ======
 - Wrap ``.sizes`` and ``.chunks``. (:pr:`42`) `Deepak Cherian`_.


### PR DESCRIPTION
Adds a bounds variable assuming equal spacing on either side of a
coordinate label. The variable is named f"{dim}_bounds" and raises
an error if there is an existing variable with the same name.

Also adds appropriate "bounds" attribute to the coordinate variable.

Fixes #35