### PR TITLE
Rework getitem

### DIFF
--- a/cf_xarray/tests/test_accessor.py
+++ b/cf_xarray/tests/test_accessor.py
@@ -105,7 +105,7 @@ def test_getitem_ancillary_variables():
 def test_rename_like():
     original = popds.copy(deep=True)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(KeyError):
         popds.cf.rename_like(airds)
 
     renamed = popds.cf["TEMP"].cf.rename_like(airds)
@@ -309,8 +309,6 @@ def test_getitem(obj, key, expected_key):
     assert key in obj.cf
 
     actual = obj.cf[key]
-    if isinstance(obj, xr.Dataset):
-        expected_key = [expected_key]
     expected = obj[expected_key]
     assert_identical(actual, expected)
 
@@ -328,10 +326,11 @@ def test_getitem_uses_coordinates():
     # POP-like dataset
     ds = popds
     assert_identical(
-        ds.cf["X"], ds.reset_coords()[["ULONG", "TLONG"]].set_coords(["ULONG", "TLONG"])
+        ds.cf[["X"]],
+        ds.reset_coords()[["ULONG", "TLONG"]].set_coords(["ULONG", "TLONG"]),
     )
     assert_identical(
-        ds.cf["Y"], ds.reset_coords()[["ULAT", "TLAT"]].set_coords(["ULAT", "TLAT"])
+        ds.cf[["Y"]], ds.reset_coords()[["ULAT", "TLAT"]].set_coords(["ULAT", "TLAT"])
     )
     assert_identical(ds.UVEL.cf["X"], ds["ULONG"].reset_coords(drop=True))
     assert_identical(ds.TEMP.cf["X"], ds["TLONG"].reset_coords(drop=True))

--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -55,7 +55,6 @@ Primarily for developer reference. Some of these could become public API if nece
     ~accessor._getattr
     ~accessor._get_axis_coord
     ~accessor._get_axis_coord_single
-    ~accessor._get_list_standard_names
     ~accessor._get_measure
     ~accessor._get_measure_variable
     accessor._CFWrappedPlotMethods._plot_decorator

--- a/doc/examples/introduction.ipynb
+++ b/doc/examples/introduction.ipynb
@@ -14,8 +14,8 @@
    "execution_count": null,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2020-07-24T20:12:00.609657Z",
-     "start_time": "2020-07-24T20:11:59.698753Z"
+     "end_time": "2020-07-28T03:18:03.264499Z",
+     "start_time": "2020-07-28T03:18:01.706628Z"
     }
    },
    "outputs": [],
@@ -37,8 +37,8 @@
    "execution_count": null,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2020-07-24T20:12:00.805176Z",
-     "start_time": "2020-07-24T20:12:00.718615Z"
+     "end_time": "2020-07-28T03:18:03.355688Z",
+     "start_time": "2020-07-28T03:18:03.266006Z"
     }
    },
    "outputs": [],
@@ -61,8 +61,8 @@
    "execution_count": null,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2020-07-24T20:12:02.140074Z",
-     "start_time": "2020-07-24T20:12:02.050083Z"
+     "end_time": "2020-07-28T03:18:03.418465Z",
+     "start_time": "2020-07-28T03:18:03.357132Z"
     }
    },
    "outputs": [],
@@ -118,8 +118,8 @@
    "execution_count": null,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2020-06-30T23:25:30.702175Z",
-     "start_time": "2020-06-30T23:25:30.653445Z"
+     "end_time": "2020-07-28T03:18:03.468916Z",
+     "start_time": "2020-07-28T03:18:03.420053Z"
     }
    },
    "outputs": [],
@@ -140,8 +140,8 @@
    "execution_count": null,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2020-06-30T23:25:30.738840Z",
-     "start_time": "2020-06-30T23:25:30.703397Z"
+     "end_time": "2020-07-28T03:18:03.496952Z",
+     "start_time": "2020-07-28T03:18:03.470068Z"
     }
    },
    "outputs": [],
@@ -184,8 +184,8 @@
    "execution_count": null,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2020-06-30T23:25:30.765720Z",
-     "start_time": "2020-06-30T23:25:30.740611Z"
+     "end_time": "2020-07-28T03:18:03.528010Z",
+     "start_time": "2020-07-28T03:18:03.498427Z"
     }
    },
    "outputs": [],
@@ -210,8 +210,8 @@
    "execution_count": null,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2020-06-30T23:25:30.784623Z",
-     "start_time": "2020-06-30T23:25:30.766855Z"
+     "end_time": "2020-07-28T03:18:03.546588Z",
+     "start_time": "2020-07-28T03:18:03.529734Z"
     }
    },
    "outputs": [],
@@ -233,8 +233,8 @@
    "execution_count": null,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2020-06-30T23:25:30.808990Z",
-     "start_time": "2020-06-30T23:25:30.786547Z"
+     "end_time": "2020-07-28T03:18:03.565233Z",
+     "start_time": "2020-07-28T03:18:03.547756Z"
     }
    },
    "outputs": [],
@@ -254,8 +254,8 @@
    "execution_count": null,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2020-06-30T23:25:30.831925Z",
-     "start_time": "2020-06-30T23:25:30.811491Z"
+     "end_time": "2020-07-28T03:18:03.595027Z",
+     "start_time": "2020-07-28T03:18:03.566478Z"
     }
    },
    "outputs": [],
@@ -278,8 +278,8 @@
    "execution_count": null,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2020-06-30T23:25:30.853404Z",
-     "start_time": "2020-06-30T23:25:30.833017Z"
+     "end_time": "2020-07-28T03:26:55.667604Z",
+     "start_time": "2020-07-28T03:26:55.475896Z"
     }
    },
    "outputs": [],
@@ -288,18 +288,11 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2020-06-30T23:25:30.874348Z",
-     "start_time": "2020-06-30T23:25:30.854712Z"
-    }
-   },
-   "outputs": [],
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
-    "# Dataset always return Datasets since there can be multiple x variables\n",
-    "ds.cf[\"X\"]"
+    "Indexing with a scalar key raises an error if the key maps to multiple variables\n",
+    "names\n"
    ]
   },
   {
@@ -307,10 +300,12 @@
    "execution_count": null,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2020-06-30T23:25:30.908034Z",
-     "start_time": "2020-06-30T23:25:30.875711Z"
+     "end_time": "2020-07-28T03:27:00.228638Z",
+     "start_time": "2020-07-28T03:27:00.209975Z"
     },
-    "scrolled": true
+    "tags": [
+     "raises-exception"
+    ]
    },
    "outputs": [],
    "source": [
@@ -318,10 +313,28 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-07-28T03:28:23.253247Z",
+     "start_time": "2020-07-28T03:28:23.213761Z"
+    },
+    "tags": [
+     "raises-exception"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "pop.cf[\"longitude\"]"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "`Dataset.cf[...]` returns a `Dataset`, possibly with multiple variables\n"
+    "To get back all variables associated with that key, pass a single element list\n",
+    "instead.\n"
    ]
   },
   {
@@ -329,13 +342,47 @@
    "execution_count": null,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2020-06-30T23:25:30.938350Z",
-     "start_time": "2020-06-30T23:25:30.909227Z"
+     "end_time": "2020-07-28T03:28:31.727351Z",
+     "start_time": "2020-07-28T03:28:31.676094Z"
     }
    },
    "outputs": [],
    "source": [
-    "# DataArrays return DataArrays\n",
+    "multiple.cf[[\"X\"]]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-07-28T03:28:35.927895Z",
+     "start_time": "2020-07-28T03:28:35.867609Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "pop.cf[[\"longitude\"]]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "DataArrays return DataArrays\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-07-28T03:28:50.626127Z",
+     "start_time": "2020-07-28T03:28:50.526332Z"
+    }
+   },
+   "outputs": [],
+   "source": [
     "pop.UVEL.cf[\"longitude\"]"
    ]
   },
@@ -353,8 +400,8 @@
    "execution_count": null,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2020-06-30T23:25:30.999763Z",
-     "start_time": "2020-06-30T23:25:30.939502Z"
+     "end_time": "2020-07-28T03:28:08.240638Z",
+     "start_time": "2020-07-28T03:28:08.170572Z"
     },
     "scrolled": true
    },
@@ -376,9 +423,10 @@
    "execution_count": null,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2020-06-30T23:25:31.050027Z",
-     "start_time": "2020-06-30T23:25:31.000741Z"
-    }
+     "end_time": "2020-07-28T03:28:09.922569Z",
+     "start_time": "2020-07-28T03:28:09.866452Z"
+    },
+    "scrolled": true
    },
    "outputs": [],
    "source": [
@@ -397,8 +445,8 @@
    "execution_count": null,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2020-06-30T23:25:31.150885Z",
-     "start_time": "2020-06-30T23:25:31.052008Z"
+     "end_time": "2020-07-28T03:18:03.776855Z",
+     "start_time": "2020-07-28T03:18:01.700Z"
     }
    },
    "outputs": [],
@@ -411,8 +459,8 @@
    "execution_count": null,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2020-06-30T23:25:31.185257Z",
-     "start_time": "2020-06-30T23:25:31.152549Z"
+     "end_time": "2020-07-28T03:18:03.777981Z",
+     "start_time": "2020-07-28T03:18:01.700Z"
     }
    },
    "outputs": [],
@@ -434,8 +482,8 @@
    "execution_count": null,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2020-07-24T20:12:06.956464Z",
-     "start_time": "2020-07-24T20:12:06.908943Z"
+     "end_time": "2020-07-28T03:18:03.779098Z",
+     "start_time": "2020-07-28T03:18:01.700Z"
     }
    },
    "outputs": [],
@@ -455,8 +503,8 @@
    "execution_count": null,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2020-07-24T20:12:36.699151Z",
-     "start_time": "2020-07-24T20:12:36.664209Z"
+     "end_time": "2020-07-28T03:18:03.780223Z",
+     "start_time": "2020-07-28T03:18:01.800Z"
     }
    },
    "outputs": [],
@@ -477,7 +525,12 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-07-28T03:18:03.781216Z",
+     "start_time": "2020-07-28T03:18:01.800Z"
+    }
+   },
    "outputs": [],
    "source": [
     "ds.cf.sizes"
@@ -499,6 +552,10 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-07-28T03:18:03.782014Z",
+     "start_time": "2020-07-28T03:18:01.800Z"
+    },
     "tags": [
      "raises-exception"
     ]
@@ -511,7 +568,12 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-07-28T03:18:03.782723Z",
+     "start_time": "2020-07-28T03:18:01.800Z"
+    }
+   },
    "outputs": [],
    "source": [
     "multiple.v1.cf.sizes"
@@ -535,7 +597,12 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-07-28T03:18:03.783410Z",
+     "start_time": "2020-07-28T03:18:01.800Z"
+    }
+   },
    "outputs": [],
    "source": [
     "pop.cf[\"TEMP\"].cf.rename_like(ds)"
@@ -567,8 +634,8 @@
    "execution_count": null,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2020-06-30T23:25:31.241228Z",
-     "start_time": "2020-06-30T23:25:31.206075Z"
+     "end_time": "2020-07-28T03:18:03.783972Z",
+     "start_time": "2020-07-28T03:18:01.800Z"
     }
    },
    "outputs": [],
@@ -589,8 +656,8 @@
    "execution_count": null,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2020-06-30T23:25:31.263144Z",
-     "start_time": "2020-06-30T23:25:31.242411Z"
+     "end_time": "2020-07-28T03:18:03.784592Z",
+     "start_time": "2020-07-28T03:18:01.800Z"
     }
    },
    "outputs": [],
@@ -610,8 +677,8 @@
    "execution_count": null,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2020-06-30T23:25:31.316816Z",
-     "start_time": "2020-06-30T23:25:31.264832Z"
+     "end_time": "2020-07-28T03:18:03.785151Z",
+     "start_time": "2020-07-28T03:18:01.800Z"
     }
    },
    "outputs": [],
@@ -631,8 +698,8 @@
    "execution_count": null,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2020-06-30T23:25:31.355791Z",
-     "start_time": "2020-06-30T23:25:31.318494Z"
+     "end_time": "2020-07-28T03:18:03.785772Z",
+     "start_time": "2020-07-28T03:18:01.800Z"
     }
    },
    "outputs": [],
@@ -653,8 +720,8 @@
    "execution_count": null,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2020-06-30T23:25:31.773401Z",
-     "start_time": "2020-06-30T23:25:31.356780Z"
+     "end_time": "2020-07-28T03:18:03.786551Z",
+     "start_time": "2020-07-28T03:18:01.800Z"
     }
    },
    "outputs": [],
@@ -667,8 +734,8 @@
    "execution_count": null,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2020-06-30T23:25:31.950102Z",
-     "start_time": "2020-06-30T23:25:31.774927Z"
+     "end_time": "2020-07-28T03:18:03.787186Z",
+     "start_time": "2020-07-28T03:18:01.800Z"
     }
    },
    "outputs": [],
@@ -688,8 +755,8 @@
    "execution_count": null,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2020-06-30T23:25:32.429977Z",
-     "start_time": "2020-06-30T23:25:31.951116Z"
+     "end_time": "2020-07-28T03:18:03.787907Z",
+     "start_time": "2020-07-28T03:18:01.800Z"
     }
    },
    "outputs": [],
@@ -709,8 +776,8 @@
    "execution_count": null,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2020-06-30T23:25:33.035768Z",
-     "start_time": "2020-06-30T23:25:32.432049Z"
+     "end_time": "2020-07-28T03:18:03.788564Z",
+     "start_time": "2020-07-28T03:18:01.800Z"
     }
    },
    "outputs": [],
@@ -723,8 +790,8 @@
    "execution_count": null,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2020-06-30T23:25:33.106698Z",
-     "start_time": "2020-06-30T23:25:33.037746Z"
+     "end_time": "2020-07-28T03:18:03.789223Z",
+     "start_time": "2020-07-28T03:18:01.900Z"
     }
    },
    "outputs": [],
@@ -744,8 +811,8 @@
    "execution_count": null,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2020-06-30T23:25:33.163025Z",
-     "start_time": "2020-06-30T23:25:33.108117Z"
+     "end_time": "2020-07-28T03:18:03.789803Z",
+     "start_time": "2020-07-28T03:18:01.900Z"
     }
    },
    "outputs": [],
@@ -780,8 +847,8 @@
    "execution_count": null,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2020-06-30T23:25:33.212324Z",
-     "start_time": "2020-06-30T23:25:33.164373Z"
+     "end_time": "2020-07-28T03:18:03.790416Z",
+     "start_time": "2020-07-28T03:18:01.900Z"
     }
    },
    "outputs": [],
@@ -804,8 +871,8 @@
    "execution_count": null,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2020-06-30T23:25:33.230790Z",
-     "start_time": "2020-06-30T23:25:33.213660Z"
+     "end_time": "2020-07-28T03:18:03.791021Z",
+     "start_time": "2020-07-28T03:18:01.900Z"
     }
    },
    "outputs": [],
@@ -826,8 +893,8 @@
    "execution_count": null,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2020-06-30T23:25:33.411012Z",
-     "start_time": "2020-06-30T23:25:33.232194Z"
+     "end_time": "2020-07-28T03:18:03.791751Z",
+     "start_time": "2020-07-28T03:18:01.900Z"
     }
    },
    "outputs": [],
@@ -853,7 +920,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.7.8"
   },
   "toc": {
    "base_numbering": 1,

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,6 +43,7 @@ include_trailing_comma = True
 force_grid_wrap = 0
 use_parentheses = True
 line_length = 88
+known_third_party = dask,matplotlib,numpy,pandas,pytest,setuptools,sphinx_autosummary_accessors,xarray
 
 # Most of the numerical computing stack doesn't have type annotations yet.
 [mypy-affine.*]


### PR DESCRIPTION
1. If passes a scalar key, there must be only one variable that matches
the key
2. To get back all variables, pass a list ds.cf[["longitude"]] for
example.

I think this is more consistent with xarray semantics.