### PR TITLE
Support for bounds.

### DIFF
--- a/cf_xarray/tests/test_accessor.py
+++ b/cf_xarray/tests/test_accessor.py
@@ -356,7 +356,7 @@ def test_plot_xincrease_yincrease():
 
 
 @pytest.mark.parametrize("dims", ["lat", "time", ["lat", "lon"]])
-@pytest.mark.parametrize("obj", [airds, airds.air])
+@pytest.mark.parametrize("obj", [airds])
 def test_add_bounds(obj, dims):
     expected = dict()
     expected["lat"] = xr.concat(
@@ -397,6 +397,26 @@ def test_add_bounds(obj, dims):
         assert name in added.coords
         assert added[dim].attrs["bounds"] == name
         assert_allclose(added[name].reset_coords(drop=True), expected[dim])
+
+
+def test_bounds():
+    ds = airds.copy(deep=True).cf.add_bounds("lat")
+    actual = ds.cf[["lat"]]
+    expected = ds[["lat", "lat_bounds"]]
+    assert_identical(actual, expected)
+
+    actual = ds.cf[["air"]]
+    assert "lat_bounds" in actual.coords
+
+    # can't associate bounds variable when providing scalar keys
+    # i.e. when DataArrays are returned
+    actual = ds.cf["lat"]
+    expected = ds["lat"]
+    assert_identical(actual, expected)
+
+    actual = ds.cf.get_bounds("lat")
+    expected = ds["lat_bounds"]
+    assert_identical(actual, expected)
 
 
 def test_docstring():

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -16,7 +16,6 @@ DataArray
    :toctree: generated/
    :template: autosummary/accessor_method.rst
 
-    DataArray.cf.add_bounds
     DataArray.cf.describe
     DataArray.cf.get_standard_names
     DataArray.cf.get_valid_keys
@@ -36,6 +35,7 @@ Dataset
 
     Dataset.cf.add_bounds
     Dataset.cf.describe
+    Dataset.cf.get_bounds
     Dataset.cf.get_standard_names
     Dataset.cf.get_valid_keys
     Dataset.cf.guess_coord_axis


### PR DESCRIPTION
Closes #32 

Return bounds variables when returning a Dataset

1. Unfortunately, we cannot return bounds variables with
   `ds.cf["latitude"]` for e.g. DataArrays cannot have
   coordinate variables with dimensions that are not on
   the core variable.

   Actually, if we go through the _to_temp_dataset,
   assign bounds to coords, then_from_temp_dataset
   route, this will work. But pretty sure that's not
   intended.

2. ds.cf[["air"]] will return bounds variables for dimensions
   if appropriate. 