### PR TITLE
update the location of sphinx-autosummary-accessors

### DIFF
--- a/ci/doc.yml
+++ b/ci/doc.yml
@@ -16,4 +16,4 @@ dependencies:
   - pip:
       - git+https://github.com/xarray-contrib/cf-xarray
       - sphinx-book-theme
-      - git+https://github.com/keewis/sphinx-autosummary-accessors
+      - git+https://github.com/xarray-contrib/sphinx-autosummary-accessors


### PR DESCRIPTION
I just moved `sphinx-autosummary-accessors` from my own organization to `xarray-contrib`. Since right now it's only used by the repositories in `xarray-contrib` I can afford to submit PRs to all of them :grinning:

Not sure when I can release that extension and upload to PyPI / conda-forge (that is currently blocked by issues with `AccessorCallable` in combination with `autosummary` – once fixed the `alias of ...` summary will be replaced by the summary line in the `__call__` docstring), but once I do I'll ping you.