### PR TITLE
install from pypi

### DIFF
--- a/ci/doc.yml
+++ b/ci/doc.yml
@@ -16,4 +16,4 @@ dependencies:
   - pip:
       - git+https://github.com/xarray-contrib/cf-xarray
       - sphinx-book-theme
-      - git+https://github.com/xarray-contrib/sphinx-autosummary-accessors
+      - sphinx-autosummary-accessors


### PR DESCRIPTION
I recently released `sphinx-autosummary-accessors`, so installing from PyPI should be preferred over installing from github. I'm also planning to create a conda-forge recipe (see xarray-contrib/sphinx-autosummary-accessors#15), but that will probably still take some time.

Edit: also, I noticed the documentation of your `.cf.plot` accessor is broken. You might fix that by using a descriptor other than `property`, see pydata/xarray#3988.