### PR TITLE
install sphinx-autosummary-accessors from conda-forge

### DIFF
--- a/ci/doc.yml
+++ b/ci/doc.yml
@@ -10,10 +10,10 @@ dependencies:
   - sphinx
   - nbsphinx
   - numpydoc
+  - sphinx-autosummary-accessors
   - ipython
   - ipykernel
   - pandas<1.1.0
   - pip:
       - git+https://github.com/xarray-contrib/cf-xarray
       - sphinx-book-theme
-      - sphinx-autosummary-accessors


### PR DESCRIPTION
The extension is on `conda-forge`, so you should be able to install that instead of falling back to `pip`.