### PR TITLE
added time frequencies to regex for T

### DIFF
--- a/cf_xarray/accessor.py
+++ b/cf_xarray/accessor.py
@@ -109,7 +109,7 @@ coordinate_criteria["long_name"] = coordinate_criteria["standard_name"]
 
 #: regular expressions for guess_coord_axis
 regex = {
-    "time": "time[0-9]*",
+    "time": "time[0-9]*|min|hour|day|week|month|year",
     "vertical": (
         "(lv_|bottom_top|sigma|h(ei)?ght|altitude|depth|isobaric|pres|"
         "isotherm)[a-z_]*[0-9]*"


### PR DESCRIPTION
My goal in this is to expand what is matched to "count" as time when `guess_coord_axis` is run to include other time frequencies that might result from for example a groupby call. With the change in this PR, the following is now possible

![image](https://user-images.githubusercontent.com/3487237/95497114-738f8880-0967-11eb-9fa4-0d91fbd92cfc.png)

This avoids needing to add attributes after the calculation 

`ds.temp.isel(xi_rho=300,s_rho=-1).cf.groupby("T.hour").mean(skipna=False)`

