### PR TITLE
Compute corners from bounds

### DIFF
--- a/cf_xarray/__init__.py
+++ b/cf_xarray/__init__.py
@@ -1,1 +1,2 @@
 from .accessor import CFAccessor  # noqa
+from .helpers import bounds_to_corners, corners_to_bounds  # noqa

--- a/cf_xarray/__init__.py
+++ b/cf_xarray/__init__.py
@@ -1,2 +1,2 @@
 from .accessor import CFAccessor  # noqa
-from .helpers import bounds_to_corners, corners_to_bounds  # noqa
+from .helpers import bounds_to_vertices, vertices_to_bounds  # noqa

--- a/cf_xarray/accessor.py
+++ b/cf_xarray/accessor.py
@@ -543,23 +543,6 @@ def _getattr(
     return wrapper
 
 
-def _bounds_are_clockwise(values):
-    """Guesses the order of the given bounds.
-
-    If we draw the bounds points, with axis 1 vertical and axis 2 horizontal,
-    this function returns whether the points are stored clockwise or counterclockwise.
-
-    Parameters
-    ----------
-    values : np.ndarray (bounds, n, m)
-
-    Returns
-    -------
-    boolean
-    """
-    pass
-
-
 class _CFWrappedClass:
     """
     This class is used to wrap any class in _WRAPPED_CLASSES.

--- a/cf_xarray/accessor.py
+++ b/cf_xarray/accessor.py
@@ -1307,8 +1307,8 @@ class CFDatasetAccessor(CFAccessor):
         # Get old and new dimension names and retranspose array to have bounds dim at axis 0.
         old_dims = self[key].dims
         bnd_dim = list(set(bounds.dims) - set(old_dims))[0]
-        new_dims = [f'{dim}_corners' for dim in old_dims]
-        name = f'{self[key].name}_corners'
+        new_dims = [f"{dim}_corners" for dim in old_dims]
+        name = f"{self[key].name}_corners"
         values = bounds.transpose(bnd_dim, *old_dims).values
         if len(old_dims) == 2 and bounds.ndim == 3 and bounds[bnd_dim].size == 4:
             # Vertices case (2D lat/lon)
@@ -1317,34 +1317,33 @@ class CFDatasetAccessor(CFAccessor):
             bot_right = values[1, :, -1:]
             top_right = values[2, -1:, -1:]
             top_left = values[3, -1:, :]
-            corner_vals = np.block([
-                [bot_left, bot_right],
-                [top_left, top_right]
-            ])
+            corner_vals = np.block([[bot_left, bot_right], [top_left, top_right]])
             calc_bnds = np.stack(
-                (corner_vals[:-1, :-1],
-                 corner_vals[:-1, 1:],
-                 corner_vals[1:, 1:],
-                 corner_vals[1:, :-1]),
-                axis=0
+                (
+                    corner_vals[:-1, :-1],
+                    corner_vals[:-1, 1:],
+                    corner_vals[1:, 1:],
+                    corner_vals[1:, :-1],
+                ),
+                axis=0,
             )
             if not np.all(calc_bnds == values):
                 bot_right = values[3, :, -1:]
                 top_left = values[1, -1:, :]
                 # Our asumption was wrong, axis 1 is rightward and axis 2 is upward
-                corner_vals = np.block([
-                    [bot_left, bot_right],
-                    [top_left, top_right]
-                ])
+                corner_vals = np.block([[bot_left, bot_right], [top_left, top_right]])
             corners = xr.DataArray(corner_vals, dims=new_dims, name=name)
         elif len(old_dims) == 1 and bounds.ndim == 2 and bounds[bnd_dim].size == 2:
             # Middle points case (1D lat/lon)
             corners = xr.DataArray(
                 np.concatenate((values[0, :], values[1, -1:])),
-                dims=(new_dims[0],), name=name
+                dims=(new_dims[0],),
+                name=name,
             )
         else:
-            raise ValueError(f'Bounds format not understood. Got {bounds.dims} with shape {bounds.shape}.')
+            raise ValueError(
+                f"Bounds format not understood. Got {bounds.dims} with shape {bounds.shape}."
+            )
 
         return corners
 

--- a/cf_xarray/accessor.py
+++ b/cf_xarray/accessor.py
@@ -18,12 +18,10 @@ from typing import (
     Union,
 )
 
-import numpy as np
 import xarray as xr
 from xarray import DataArray, Dataset
 
 from .helpers import bounds_to_corners
-
 
 #: Classes wrapped by cf_xarray.
 _WRAPPED_CLASSES = (
@@ -1334,9 +1332,9 @@ class CFDatasetAccessor(CFAccessor):
         return self._maybe_to_dataarray(obj)
 
     def bounds_to_corners(
-            self,
-            keys: Optional[Union[str, Iterable[str]]] = None,
-            order: Optional[str] = 'counterclockwise'
+        self,
+        keys: Optional[Union[str, Iterable[str]]] = None,
+        order: Optional[str] = "counterclockwise",
     ) -> Dataset:
         """
         Convert bounds variable to corners.
@@ -1373,7 +1371,7 @@ class CFDatasetAccessor(CFAccessor):
             If any of the keys given doesn't corresponds to existing bounds.
         """
         if keys is None:
-            coords = self.keys()
+            coords: Iterable[str] = self.keys()
         elif isinstance(keys, str):
             coords = (keys,)
         else:
@@ -1386,16 +1384,22 @@ class CFDatasetAccessor(CFAccessor):
                 bounds = self.get_bounds(coord)
             except KeyError as exc:
                 if keys is not None:
-                    raise ValueError(f'Corners are computed from bounds but given key {coord} did not correspond to existing bounds.') from exc
+                    raise ValueError(
+                        f"Corners are computed from bounds but given key {coord} did not correspond to existing bounds."
+                    ) from exc
             else:
-                name = f'{self[coord].name}_corners'
+                name = f"{self[coord].name}_corners"
                 if name not in obj:
                     obj = obj.assign(
-                        {name: bounds_to_corners(
-                            bounds,
-                            bounds_dim=list(set(bounds.dims) - set(self[coord].dims))[0],
-                            order=order
-                        )}
+                        {
+                            name: bounds_to_corners(
+                                bounds,
+                                bounds_dim=list(
+                                    set(bounds.dims) - set(self[coord].dims)
+                                )[0],
+                                order=order,
+                            )
+                        }
                     )
         return obj
 

--- a/cf_xarray/accessor.py
+++ b/cf_xarray/accessor.py
@@ -12,7 +12,6 @@ from typing import (
     List,
     Mapping,
     MutableMapping,
-    Optional,
     Set,
     Tuple,
     Union,
@@ -1333,8 +1332,8 @@ class CFDatasetAccessor(CFAccessor):
 
     def bounds_to_vertices(
         self,
-        keys: Optional[Union[str, Iterable[str]]] = None,
-        order: Optional[str] = "counterclockwise",
+        keys: Union[str, Iterable[str]] = None,
+        order: str = "counterclockwise",
     ) -> Dataset:
         """
         Convert bounds variable to vertices.
@@ -1345,17 +1344,16 @@ class CFDatasetAccessor(CFAccessor):
          - 2D coordinates, with bounds of shape (N, M, 4).
            converted to vertices of shape (N+1, M+1).
 
-
         Parameters
         ----------
         keys : str or Iterable[str], optional
             The names of the variables whose bounds are to be converted to vertices.
             If not given, converts all available bounds within self.cf.keys().
-        order : {'counterclockwise', 'ccw', 'clockwise', 'cw', None}
-            Valid for 2D coordinates only (bounds of shape NxMx4), ignored otherwise.
-            Order the bounds are given in, assuming that axis0-axis1-upward
-            is a right handed coordinate system.
-            If None, the counterclockwise version is computed and then
+        order : {'counterclockwise', 'clockwise', None}
+            Valid for 2D coordinates only (bounds of shape (N, M, 4), ignored otherwise.
+            Order the bounds are given in, assuming that ax0-ax1-upward is a right
+            handed coordinate system, where ax0 and ax1 are the two first dimensions of
+            the variable. If None, the counterclockwise version is computed and then
             verified. If the check fails the clockwise version is returned.
 
         Returns
@@ -1363,12 +1361,23 @@ class CFDatasetAccessor(CFAccessor):
         Dataset
             Copy of the dataset with added vertices variables.
             Either of shape (N+1,) or (N+1, M+1). New vertex dimensions are named
-            from the intial dimension and suffix "_vertices".
+            from the intial dimension and suffix "_vertices". Variables with similar
+            names are overwritten.
 
         Raises
         ------
         ValueError
             If any of the keys given doesn't corresponds to existing bounds.
+
+        Notes
+        -----
+        Getting the correct axes "order" is tricky. There are no real standards for
+        dimension names or even axes order, even though the CF conventions mentions the
+        ax0-ax1-upward (counterclockwise bounds) as being the default. Moreover, xarray can
+        tranpose data without raising any warning or error, which make attributes
+        unreliable.
+
+        Please refer to the CF conventions document : http://cfconventions.org/Data/cf-conventions/cf-conventions-1.8/cf-conventions.html#cell-boundaries.
         """
         if keys is None:
             coords: Iterable[str] = self.keys()
@@ -1389,18 +1398,17 @@ class CFDatasetAccessor(CFAccessor):
                     ) from exc
             else:
                 name = f"{self[coord].name}_vertices"
-                if name not in obj:
-                    obj = obj.assign(
-                        {
-                            name: bounds_to_vertices(
-                                bounds,
-                                bounds_dim=list(
-                                    set(bounds.dims) - set(self[coord].dims)
-                                )[0],
-                                order=order,
-                            )
-                        }
-                    )
+                obj = obj.assign(  # Overwrite any variable with the same name.
+                    {
+                        name: bounds_to_vertices(
+                            bounds,
+                            bounds_dim=list(set(bounds.dims) - set(self[coord].dims))[
+                                0
+                            ],
+                            order=order,
+                        )
+                    }
+                )
         return obj
 
     def decode_vertical_coords(self, prefix="z"):

--- a/cf_xarray/accessor.py
+++ b/cf_xarray/accessor.py
@@ -21,7 +21,7 @@ from typing import (
 import xarray as xr
 from xarray import DataArray, Dataset
 
-from .helpers import bounds_to_corners
+from .helpers import bounds_to_vertices
 
 #: Classes wrapped by cf_xarray.
 _WRAPPED_CLASSES = (
@@ -1331,25 +1331,25 @@ class CFDatasetAccessor(CFAccessor):
 
         return self._maybe_to_dataarray(obj)
 
-    def bounds_to_corners(
+    def bounds_to_vertices(
         self,
         keys: Optional[Union[str, Iterable[str]]] = None,
         order: Optional[str] = "counterclockwise",
     ) -> Dataset:
         """
-        Convert bounds variable to corners.
+        Convert bounds variable to vertices.
 
         There 2 covered cases:
          - 1D coordinates, with bounds of shape (N, 2),
-           converted to corners of shape (N+1,)
+           converted to vertices of shape (N+1,)
          - 2D coordinates, with bounds of shape (N, M, 4).
-           converted to corners of shape (N+1, M+1).
+           converted to vertices of shape (N+1, M+1).
 
 
         Parameters
         ----------
         keys : str or Iterable[str], optional
-            The names of the variables whose bounds are to be converted to corners.
+            The names of the variables whose bounds are to be converted to vertices.
             If not given, converts all available bounds within self.cf.keys().
         order : {'counterclockwise', 'ccw', 'clockwise', 'cw', None}
             Valid for 2D coordinates only (bounds of shape NxMx4), ignored otherwise.
@@ -1361,9 +1361,9 @@ class CFDatasetAccessor(CFAccessor):
         Returns
         -------
         Dataset
-            Copy of the dataset with added corners variables.
-            Either of shape (N+1,) or (N+1, M+1). New corner dimensions are named
-            from the intial dimension and suffix "_corners".
+            Copy of the dataset with added vertices variables.
+            Either of shape (N+1,) or (N+1, M+1). New vertex dimensions are named
+            from the intial dimension and suffix "_vertices".
 
         Raises
         ------
@@ -1385,14 +1385,14 @@ class CFDatasetAccessor(CFAccessor):
             except KeyError as exc:
                 if keys is not None:
                     raise ValueError(
-                        f"Corners are computed from bounds but given key {coord} did not correspond to existing bounds."
+                        f"vertices are computed from bounds but given key {coord} did not correspond to existing bounds."
                     ) from exc
             else:
-                name = f"{self[coord].name}_corners"
+                name = f"{self[coord].name}_vertices"
                 if name not in obj:
                     obj = obj.assign(
                         {
-                            name: bounds_to_corners(
+                            name: bounds_to_vertices(
                                 bounds,
                                 bounds_dim=list(
                                     set(bounds.dims) - set(self[coord].dims)

--- a/cf_xarray/helpers.py
+++ b/cf_xarray/helpers.py
@@ -1,0 +1,105 @@
+from typing import Optional, Sequence
+
+import numpy as np
+import xarray as xr
+from xarray import DataArray
+
+
+def bounds_to_corners(
+    bounds: DataArray, bounds_dim: str, order: Optional[str] = "counterclockwise"
+) -> DataArray:
+    """
+    Convert bounds variable to corners. There 2 covered cases:
+     - 1D coordinates, with bounds of shape (N, 2),
+       converted to corners of shape (N+1,)
+     - 2D coordinates, with bounds of shape (N, M, 4).
+       converted to corners of shape (N+1, M+1).
+
+    Parameters
+    ----------
+    bounds: DataArray
+        The bounds to convert. Must be of shape (N, 2) or (N, M, 4).
+    bounds_dim : str
+        The name of the bounds dimension of `bounds` (the one of length 2 or 4).
+    order : {'counterclockwise', 'ccw', 'clockwise', 'cw', None}
+        Valid for 2D coordinates only (bounds of shape (N, M, 4), ignored otherwise.
+        Order the bounds are given in, assuming that axis0-axis1-upward
+        is a right handed coordinate system.
+        If None, the counterclockwise version is computed and then
+        verified. If the check fails the clockwise version is returned.
+    Returns
+    -------
+    DataArray
+        Either of shape (N+1,) or (N+1, M+1). New corner dimensions are named
+        from the intial dimension and suffix "_corners".
+    """
+    # Get old and new dimension names and retranspose array to have bounds dim at axis 0.
+    bnd_dim = (
+        bounds_dim if isinstance(bounds_dim, str) else bounds.get_axis_num(bounds_dim)
+    )
+    old_dims = [dim for dim in bounds.dims if dim != bnd_dim]
+    new_dims = [f"{dim}_corners" for dim in old_dims]
+    values = bounds.transpose(bnd_dim, *old_dims).values
+    if len(old_dims) == 2 and bounds.ndim == 3 and bounds[bnd_dim].size == 4:
+        # Vertices case (2D lat/lon)
+        if order in ["counterclockwise", "ccw", None]:
+            # Names assume we are drawing axis 1 upward et axis 2 rightward.
+            bot_left = values[0, :, :]
+            bot_right = values[1, :, -1:]
+            top_right = values[2, -1:, -1:]
+            top_left = values[3, -1:, :]
+            corner_vals = np.block([[bot_left, bot_right], [top_left, top_right]])
+        if order is None:  # We verify if the ccw version works.
+            calc_bnds = corners_to_bounds(corner_vals).values
+            order = "ccw" if np.all(calc_bnds == values) else "cw"
+        if order in ["cw", "clockwise"]:
+            bot_left = values[0, :, :]
+            top_left = values[1, -1:, :]
+            top_right = values[2, -1:, -1:]
+            bot_right = values[3, :, -1:]
+            # Our asumption was wrong, axis 1 is rightward and axis 2 is upward
+            corner_vals = np.block([[bot_left, bot_right], [top_left, top_right]])
+    elif len(old_dims) == 1 and bounds.ndim == 2 and bounds[bnd_dim].size == 2:
+        # Middle points case (1D lat/lon)
+        corner_vals = np.concatenate((values[0, :], values[1, -1:]))
+    else:
+        raise ValueError(
+            f"Bounds format not understood. Got {bounds.dims} with shape {bounds.shape}."
+        )
+
+    return xr.DataArray(corner_vals, dims=new_dims)
+
+
+def corners_to_bounds(
+    corners: DataArray, out_dims: Sequence[str] = ("bounds", "x", "y")
+) -> DataArray:
+    """
+    Convert corners to CF-compliant bounds. There 2 covered cases:
+     - 1D coordinates, with corners of shape (N+1,),
+       converted to bounds of shape (N, 2)
+     - 2D coordinates, with corners of shape (N+1, M+1).
+       converted to bounds of shape (N, M, 4).
+
+    Parameters
+    ----------
+    bounds: DataArray
+        The bounds to convert. Must be of shape (N, 2) or (N, M, 4).
+    out_dims : Sequence[str],
+        The name of the dimension in the output. The first is the 'bounds'
+        dimension and the following are the coordinate dimensions.
+    Returns
+    -------
+    DataArray
+    """
+    if corners.ndim == 1:
+        bnd_vals = np.stack((corners[:-1], corners[1:]), axis=0)
+    elif corners.ndim == 2:
+        bnd_vals = np.stack(
+            (corners[:-1, :-1], corners[:-1, 1:], corners[1:, 1:], corners[1:, :-1]),
+            axis=0,
+        )
+    else:
+        raise ValueError(
+            f"Corners format not understood. Got {corners.dims} with shape {corners.shape}."
+        )
+    return xr.DataArray(bnd_vals, dims=out_dims[: corners.ndim + 1])

--- a/cf_xarray/tests/datasets.py
+++ b/cf_xarray/tests/datasets.py
@@ -142,24 +142,24 @@ lat = np.rad2deg(np.arcsin((2 * theta + np.sin(2 * theta)) / np.pi))
 lon = np.rad2deg(XX * np.pi / (R * 2 * np.sqrt(2) * np.cos(theta)))
 
 theta_bnds = np.arcsin(YY_bnds / (R * np.sqrt(2)))
-lat_corners = np.rad2deg(np.arcsin((2 * theta_bnds + np.sin(2 * theta_bnds)) / np.pi))
-lon_corners = np.rad2deg(XX_bnds * np.pi / (R * 2 * np.sqrt(2) * np.cos(theta_bnds)))
+lat_vertices = np.rad2deg(np.arcsin((2 * theta_bnds + np.sin(2 * theta_bnds)) / np.pi))
+lon_vertices = np.rad2deg(XX_bnds * np.pi / (R * 2 * np.sqrt(2) * np.cos(theta_bnds)))
 
 lon_bounds = np.stack(
     (
-        lon_corners[:-1, :-1],
-        lon_corners[:-1, 1:],
-        lon_corners[1:, 1:],
-        lon_corners[1:, :-1],
+        lon_vertices[:-1, :-1],
+        lon_vertices[:-1, 1:],
+        lon_vertices[1:, 1:],
+        lon_vertices[1:, :-1],
     ),
     axis=0,
 )
 lat_bounds = np.stack(
     (
-        lat_corners[:-1, :-1],
-        lat_corners[:-1, 1:],
-        lat_corners[1:, 1:],
-        lat_corners[1:, :-1],
+        lat_vertices[:-1, :-1],
+        lat_vertices[:-1, 1:],
+        lat_vertices[1:, 1:],
+        lat_vertices[1:, :-1],
     ),
     axis=0,
 )
@@ -184,7 +184,7 @@ mollwds = xr.Dataset(
         lat_bounds=xr.DataArray(
             lat_bounds, dims=("bounds", "x", "y"), attrs={"units": "degrees_north"}
         ),
-        lon_corners=xr.DataArray(lon_corners, dims=("x_corners", "y_corners")),
-        lat_corners=xr.DataArray(lat_corners, dims=("x_corners", "y_corners")),
+        lon_vertices=xr.DataArray(lon_vertices, dims=("x_vertices", "y_vertices")),
+        lat_vertices=xr.DataArray(lat_vertices, dims=("x_vertices", "y_vertices")),
     ),
 )

--- a/cf_xarray/tests/datasets.py
+++ b/cf_xarray/tests/datasets.py
@@ -146,23 +146,45 @@ lat_corners = np.rad2deg(np.arcsin((2 * theta_bnds + np.sin(2 * theta_bnds)) / n
 lon_corners = np.rad2deg(XX_bnds * np.pi / (R * 2 * np.sqrt(2) * np.cos(theta_bnds)))
 
 lon_bounds = np.stack(
-    (lon_corners[:-1, :-1], lon_corners[:-1, 1:], lon_corners[1:, 1:], lon_corners[1:, :-1]),
-    axis=0
+    (
+        lon_corners[:-1, :-1],
+        lon_corners[:-1, 1:],
+        lon_corners[1:, 1:],
+        lon_corners[1:, :-1],
+    ),
+    axis=0,
 )
 lat_bounds = np.stack(
-    (lat_corners[:-1, :-1], lat_corners[:-1, 1:], lat_corners[1:, 1:], lat_corners[1:, :-1]),
-    axis=0
+    (
+        lat_corners[:-1, :-1],
+        lat_corners[:-1, 1:],
+        lat_corners[1:, 1:],
+        lat_corners[1:, :-1],
+    ),
+    axis=0,
 )
 
 mollwds = xr.Dataset(
     coords=dict(
-        lon=xr.DataArray(lon, dims=('x', 'y'), attrs={'units': 'degrees_east', 'bounds': 'lon_bounds'}),
-        lat=xr.DataArray(lat, dims=('x', 'y'), attrs={'units': 'degrees_north', 'bounds': 'lat_bounds'}),
+        lon=xr.DataArray(
+            lon,
+            dims=("x", "y"),
+            attrs={"units": "degrees_east", "bounds": "lon_bounds"},
+        ),
+        lat=xr.DataArray(
+            lat,
+            dims=("x", "y"),
+            attrs={"units": "degrees_north", "bounds": "lat_bounds"},
+        ),
     ),
     data_vars=dict(
-        lon_bounds=xr.DataArray(lon_bounds, dims=('bounds', 'x', 'y'), attrs={'units': 'degrees_east'}),
-        lat_bounds=xr.DataArray(lat_bounds, dims=('bounds', 'x', 'y'), attrs={'units': 'degrees_north'}),
-        lon_corners=xr.DataArray(lon_corners, dims=('x_corners', 'y_corners')),
-        lat_corners=xr.DataArray(lat_corners, dims=('x_corners', 'y_corners'))
-    )
+        lon_bounds=xr.DataArray(
+            lon_bounds, dims=("bounds", "x", "y"), attrs={"units": "degrees_east"}
+        ),
+        lat_bounds=xr.DataArray(
+            lat_bounds, dims=("bounds", "x", "y"), attrs={"units": "degrees_north"}
+        ),
+        lon_corners=xr.DataArray(lon_corners, dims=("x_corners", "y_corners")),
+        lat_corners=xr.DataArray(lat_corners, dims=("x_corners", "y_corners")),
+    ),
 )

--- a/cf_xarray/tests/datasets.py
+++ b/cf_xarray/tests/datasets.py
@@ -130,3 +130,39 @@ romsds.coords["z_rho_dummy"] = (
     np.random.randn(2, 30),
     {"positive": "up"},
 )
+
+
+# Dataset with random data on a grid that is some sort of Mollweide projection
+XX, YY = np.mgrid[:11, :11] * 5 - 25
+XX_bnds, YY_bnds = np.mgrid[:12, :12] * 5 - 27.5
+
+R = 50
+theta = np.arcsin(YY / (R * np.sqrt(2)))
+lat = np.rad2deg(np.arcsin((2 * theta + np.sin(2 * theta)) / np.pi))
+lon = np.rad2deg(XX * np.pi / (R * 2 * np.sqrt(2) * np.cos(theta)))
+
+theta_bnds = np.arcsin(YY_bnds / (R * np.sqrt(2)))
+lat_corners = np.rad2deg(np.arcsin((2 * theta_bnds + np.sin(2 * theta_bnds)) / np.pi))
+lon_corners = np.rad2deg(XX_bnds * np.pi / (R * 2 * np.sqrt(2) * np.cos(theta_bnds)))
+
+lon_bounds = np.stack(
+    (lon_corners[:-1, :-1], lon_corners[:-1, 1:], lon_corners[1:, 1:], lon_corners[1:, :-1]),
+    axis=0
+)
+lat_bounds = np.stack(
+    (lat_corners[:-1, :-1], lat_corners[:-1, 1:], lat_corners[1:, 1:], lat_corners[1:, :-1]),
+    axis=0
+)
+
+mollwds = xr.Dataset(
+    coords=dict(
+        lon=xr.DataArray(lon, dims=('x', 'y'), attrs={'units': 'degrees_east', 'bounds': 'lon_bounds'}),
+        lat=xr.DataArray(lat, dims=('x', 'y'), attrs={'units': 'degrees_north', 'bounds': 'lat_bounds'}),
+    ),
+    data_vars=dict(
+        lon_bounds=xr.DataArray(lon_bounds, dims=('bounds', 'x', 'y'), attrs={'units': 'degrees_east'}),
+        lat_bounds=xr.DataArray(lat_bounds, dims=('bounds', 'x', 'y'), attrs={'units': 'degrees_north'}),
+        lon_corners=xr.DataArray(lon_corners, dims=('x_corners', 'y_corners')),
+        lat_corners=xr.DataArray(lat_corners, dims=('x_corners', 'y_corners'))
+    )
+)

--- a/cf_xarray/tests/test_accessor.py
+++ b/cf_xarray/tests/test_accessor.py
@@ -9,7 +9,7 @@ from xarray.testing import assert_allclose, assert_identical
 import cf_xarray  # noqa
 
 from . import raise_if_dask_computes
-from .datasets import airds, anc, ds_no_attrs, multiple, popds
+from .datasets import airds, anc, ds_no_attrs, mollwds, multiple, popds
 
 mpl.use("Agg")
 
@@ -427,6 +427,27 @@ def test_bounds():
     actual = ds.cf.get_bounds("lat")
     expected = ds["lat_bounds"]
     assert_identical(actual, expected)
+
+
+def test_get_corners():
+    # 1D case
+    ds = airds.cf.add_bounds(['lon', 'lat'])
+    lat_c = ds.cf.get_corners('latitude')
+    lon_c = ds.cf.get_corners('longitude')
+    assert np.all(ds.lat.values + 1.25 == lat_c.values[:-1])
+    assert np.all(ds.lon.values - 1.25 == lon_c.values[:-1])
+
+    # 2D case
+    lat_c = mollwds.cf.get_corners('latitude')
+    lon_c = mollwds.cf.get_corners('longitude')
+    assert_identical(mollwds.lat_corners, lat_c)
+    assert_identical(mollwds.lon_corners, lon_c)
+    # Transposing the array changes the bounds direction
+    ds = mollwds.transpose('bounds', 'y', 'x', 'y_corners', 'x_corners')
+    lat_c = ds.cf.get_corners('latitude')
+    lon_c = ds.cf.get_corners('longitude')
+    assert_identical(ds.lat_corners, lat_c)
+    assert_identical(ds.lon_corners, lon_c)
 
 
 def test_docstring():

--- a/cf_xarray/tests/test_accessor.py
+++ b/cf_xarray/tests/test_accessor.py
@@ -431,21 +431,21 @@ def test_bounds():
 
 def test_get_corners():
     # 1D case
-    ds = airds.cf.add_bounds(['lon', 'lat'])
-    lat_c = ds.cf.get_corners('latitude')
-    lon_c = ds.cf.get_corners('longitude')
+    ds = airds.cf.add_bounds(["lon", "lat"])
+    lat_c = ds.cf.get_corners("latitude")
+    lon_c = ds.cf.get_corners("longitude")
     assert np.all(ds.lat.values + 1.25 == lat_c.values[:-1])
     assert np.all(ds.lon.values - 1.25 == lon_c.values[:-1])
 
     # 2D case
-    lat_c = mollwds.cf.get_corners('latitude')
-    lon_c = mollwds.cf.get_corners('longitude')
+    lat_c = mollwds.cf.get_corners("latitude")
+    lon_c = mollwds.cf.get_corners("longitude")
     assert_identical(mollwds.lat_corners, lat_c)
     assert_identical(mollwds.lon_corners, lon_c)
     # Transposing the array changes the bounds direction
-    ds = mollwds.transpose('bounds', 'y', 'x', 'y_corners', 'x_corners')
-    lat_c = ds.cf.get_corners('latitude')
-    lon_c = ds.cf.get_corners('longitude')
+    ds = mollwds.transpose("bounds", "y", "x", "y_corners", "x_corners")
+    lat_c = ds.cf.get_corners("latitude")
+    lon_c = ds.cf.get_corners("longitude")
     assert_identical(ds.lat_corners, lat_c)
     assert_identical(ds.lon_corners, lon_c)
 

--- a/cf_xarray/tests/test_accessor.py
+++ b/cf_xarray/tests/test_accessor.py
@@ -429,25 +429,25 @@ def test_bounds():
     assert_identical(actual, expected)
 
 
-def test_bounds_to_corners():
+def test_bounds_to_vertices():
     # All available
     ds = airds.cf.add_bounds(["lon", "lat"])
-    dsc = ds.cf.bounds_to_corners()
-    assert "lon_corners" in dsc
-    assert "lat_corners" in dsc
+    dsc = ds.cf.bounds_to_vertices()
+    assert "lon_vertices" in dsc
+    assert "lat_vertices" in dsc
 
     # Giving key
-    dsc = ds.cf.bounds_to_corners("longitude")
-    assert "lon_corners" in dsc
-    assert "lat_corners" not in dsc
+    dsc = ds.cf.bounds_to_vertices("longitude")
+    assert "lon_vertices" in dsc
+    assert "lat_vertices" not in dsc
 
-    dsc = ds.cf.bounds_to_corners(["longitude", "latitude"])
-    assert "lon_corners" in dsc
-    assert "lat_corners" in dsc
+    dsc = ds.cf.bounds_to_vertices(["longitude", "latitude"])
+    assert "lon_vertices" in dsc
+    assert "lat_vertices" in dsc
 
     # Error
     with pytest.raises(ValueError):
-        dsc = ds.cf.bounds_to_corners("T")
+        dsc = ds.cf.bounds_to_vertices("T")
 
 
 def test_docstring():

--- a/cf_xarray/tests/test_accessor.py
+++ b/cf_xarray/tests/test_accessor.py
@@ -451,7 +451,7 @@ def test_bounds_to_vertices():
 
     # Words on datetime arrays to
     ds = airds.cf.add_bounds("time")
-    dsc = ds.cf.bounds_to_corners()
+    dsc = ds.cf.bounds_to_vertices()
     assert "time_bounds" in dsc
 
 

--- a/cf_xarray/tests/test_accessor.py
+++ b/cf_xarray/tests/test_accessor.py
@@ -449,6 +449,11 @@ def test_bounds_to_vertices():
     with pytest.raises(ValueError):
         dsc = ds.cf.bounds_to_vertices("T")
 
+    # Words on datetime arrays to
+    ds = airds.cf.add_bounds("time")
+    dsc = ds.cf.bounds_to_corners()
+    assert "time_bounds" in dsc
+
 
 def test_docstring():
     assert "One of ('X'" in airds.cf.groupby.__doc__

--- a/cf_xarray/tests/test_accessor.py
+++ b/cf_xarray/tests/test_accessor.py
@@ -431,23 +431,23 @@ def test_bounds():
 
 def test_bounds_to_corners():
     # All available
-    ds = airds.cf.add_bounds(['lon', 'lat'])
+    ds = airds.cf.add_bounds(["lon", "lat"])
     dsc = ds.cf.bounds_to_corners()
-    assert 'lon_corners' in dsc
-    assert 'lat_corners' in dsc
+    assert "lon_corners" in dsc
+    assert "lat_corners" in dsc
 
     # Giving key
-    dsc = ds.cf.bounds_to_corners('longitude')
-    assert 'lon_corners' in dsc
-    assert 'lat_corners' not in dsc
+    dsc = ds.cf.bounds_to_corners("longitude")
+    assert "lon_corners" in dsc
+    assert "lat_corners" not in dsc
 
-    dsc = ds.cf.bounds_to_corners(['longitude', 'latitude'])
-    assert 'lon_corners' in dsc
-    assert 'lat_corners' in dsc
+    dsc = ds.cf.bounds_to_corners(["longitude", "latitude"])
+    assert "lon_corners" in dsc
+    assert "lat_corners" in dsc
 
     # Error
     with pytest.raises(ValueError):
-        dsc = ds.cf.bounds_to_corners('T')
+        dsc = ds.cf.bounds_to_corners("T")
 
 
 def test_docstring():

--- a/cf_xarray/tests/test_accessor.py
+++ b/cf_xarray/tests/test_accessor.py
@@ -9,7 +9,7 @@ from xarray.testing import assert_allclose, assert_identical
 import cf_xarray  # noqa
 
 from . import raise_if_dask_computes
-from .datasets import airds, anc, ds_no_attrs, mollwds, multiple, popds
+from .datasets import airds, anc, ds_no_attrs, multiple, popds
 
 mpl.use("Agg")
 
@@ -429,25 +429,25 @@ def test_bounds():
     assert_identical(actual, expected)
 
 
-def test_get_corners():
-    # 1D case
-    ds = airds.cf.add_bounds(["lon", "lat"])
-    lat_c = ds.cf.get_corners("latitude")
-    lon_c = ds.cf.get_corners("longitude")
-    assert np.all(ds.lat.values + 1.25 == lat_c.values[:-1])
-    assert np.all(ds.lon.values - 1.25 == lon_c.values[:-1])
+def test_bounds_to_corners():
+    # All available
+    ds = airds.cf.add_bounds(['lon', 'lat'])
+    dsc = ds.cf.bounds_to_corners()
+    assert 'lon_corners' in dsc
+    assert 'lat_corners' in dsc
 
-    # 2D case
-    lat_c = mollwds.cf.get_corners("latitude")
-    lon_c = mollwds.cf.get_corners("longitude")
-    assert_identical(mollwds.lat_corners, lat_c)
-    assert_identical(mollwds.lon_corners, lon_c)
-    # Transposing the array changes the bounds direction
-    ds = mollwds.transpose("bounds", "y", "x", "y_corners", "x_corners")
-    lat_c = ds.cf.get_corners("latitude")
-    lon_c = ds.cf.get_corners("longitude")
-    assert_identical(ds.lat_corners, lat_c)
-    assert_identical(ds.lon_corners, lon_c)
+    # Giving key
+    dsc = ds.cf.bounds_to_corners('longitude')
+    assert 'lon_corners' in dsc
+    assert 'lat_corners' not in dsc
+
+    dsc = ds.cf.bounds_to_corners(['longitude', 'latitude'])
+    assert 'lon_corners' in dsc
+    assert 'lat_corners' in dsc
+
+    # Error
+    with pytest.raises(ValueError):
+        dsc = ds.cf.bounds_to_corners('T')
 
 
 def test_docstring():

--- a/cf_xarray/tests/test_helpers.py
+++ b/cf_xarray/tests/test_helpers.py
@@ -1,0 +1,36 @@
+import numpy as np
+from numpy.testing import assert_array_equal
+
+import cf_xarray as cf  # noqa
+
+from .datasets import airds, mollwds
+
+
+def test_bounds_to_corners():
+    # 1D case
+    ds = airds.cf.add_bounds(["lon", "lat"])
+    lat_c = cf.bounds_to_corners(ds.lat_bounds, bounds_dim="bounds")
+    assert np.all(ds.lat.values + 1.25 == lat_c.values[:-1])
+
+    # 2D case, CF- order
+    lat_c = cf.bounds_to_corners(mollwds.lat_bounds, bounds_dim="bounds")
+    assert mollwds.lat_corners.equals(lat_c)
+
+    # Transposing the array changes the bounds direction
+    ds = mollwds.transpose("bounds", "y", "x", "y_corners", "x_corners")
+    lon_c = cf.bounds_to_corners(ds.lon_bounds, bounds_dim="bounds", order="clockwise")
+    lon_c2 = cf.bounds_to_corners(ds.lon_bounds, bounds_dim="bounds", order=None)
+    assert ds.lon_corners.equals(lon_c)
+    assert ds.lon_corners.equals(lon_c2)
+
+
+def test_corners_to_bounds():
+    # 1D case
+    ds = airds.cf.add_bounds(["lon", "lat"])
+    lat_c = cf.bounds_to_corners(ds.lat_bounds, bounds_dim="bounds")
+    lat_b = cf.corners_to_bounds(lat_c, out_dims=("bounds", "lat"))
+    assert_array_equal(ds.lat_bounds, lat_b)
+
+    # 2D case
+    lon_b = cf.corners_to_bounds(mollwds.lon_corners, out_dims=("bounds", "x", "y"))
+    assert (mollwds.lon_bounds == lon_b).all()

--- a/cf_xarray/tests/test_helpers.py
+++ b/cf_xarray/tests/test_helpers.py
@@ -6,31 +6,31 @@ import cf_xarray as cf  # noqa
 from .datasets import airds, mollwds
 
 
-def test_bounds_to_corners():
+def test_bounds_to_vertices():
     # 1D case
     ds = airds.cf.add_bounds(["lon", "lat"])
-    lat_c = cf.bounds_to_corners(ds.lat_bounds, bounds_dim="bounds")
+    lat_c = cf.bounds_to_vertices(ds.lat_bounds, bounds_dim="bounds")
     assert np.all(ds.lat.values + 1.25 == lat_c.values[:-1])
 
     # 2D case, CF- order
-    lat_c = cf.bounds_to_corners(mollwds.lat_bounds, bounds_dim="bounds")
-    assert mollwds.lat_corners.equals(lat_c)
+    lat_c = cf.bounds_to_vertices(mollwds.lat_bounds, bounds_dim="bounds")
+    assert mollwds.lat_vertices.equals(lat_c)
 
     # Transposing the array changes the bounds direction
-    ds = mollwds.transpose("bounds", "y", "x", "y_corners", "x_corners")
-    lon_c = cf.bounds_to_corners(ds.lon_bounds, bounds_dim="bounds", order="clockwise")
-    lon_c2 = cf.bounds_to_corners(ds.lon_bounds, bounds_dim="bounds", order=None)
-    assert ds.lon_corners.equals(lon_c)
-    assert ds.lon_corners.equals(lon_c2)
+    ds = mollwds.transpose("bounds", "y", "x", "y_vertices", "x_vertices")
+    lon_c = cf.bounds_to_vertices(ds.lon_bounds, bounds_dim="bounds", order="clockwise")
+    lon_c2 = cf.bounds_to_vertices(ds.lon_bounds, bounds_dim="bounds", order=None)
+    assert ds.lon_vertices.equals(lon_c)
+    assert ds.lon_vertices.equals(lon_c2)
 
 
-def test_corners_to_bounds():
+def test_vertices_to_bounds():
     # 1D case
     ds = airds.cf.add_bounds(["lon", "lat"])
-    lat_c = cf.bounds_to_corners(ds.lat_bounds, bounds_dim="bounds")
-    lat_b = cf.corners_to_bounds(lat_c, out_dims=("bounds", "lat"))
+    lat_c = cf.bounds_to_vertices(ds.lat_bounds, bounds_dim="bounds")
+    lat_b = cf.vertices_to_bounds(lat_c, out_dims=("bounds", "lat"))
     assert_array_equal(ds.lat_bounds, lat_b)
 
     # 2D case
-    lon_b = cf.corners_to_bounds(mollwds.lon_corners, out_dims=("bounds", "x", "y"))
+    lon_b = cf.vertices_to_bounds(mollwds.lon_vertices, out_dims=("bounds", "x", "y"))
     assert (mollwds.lon_bounds == lon_b).all()

--- a/cf_xarray/tests/test_helpers.py
+++ b/cf_xarray/tests/test_helpers.py
@@ -1,36 +1,56 @@
-import numpy as np
 from numpy.testing import assert_array_equal
+from xarray.testing import assert_equal
 
-import cf_xarray as cf  # noqa
+import cf_xarray as cfxr  # noqa
 
 from .datasets import airds, mollwds
+
+try:
+    from dask.array import Array as DaskArray
+except ImportError:
+    DaskArray = None
 
 
 def test_bounds_to_vertices():
     # 1D case
-    ds = airds.cf.add_bounds(["lon", "lat"])
-    lat_c = cf.bounds_to_vertices(ds.lat_bounds, bounds_dim="bounds")
-    assert np.all(ds.lat.values + 1.25 == lat_c.values[:-1])
+    ds = airds.cf.add_bounds(["lon", "lat", "time"])
+    lat_c = cfxr.bounds_to_vertices(ds.lat_bounds, bounds_dim="bounds")
+    assert_array_equal(ds.lat.values + 1.25, lat_c.values[:-1])
 
     # 2D case, CF- order
-    lat_c = cf.bounds_to_vertices(mollwds.lat_bounds, bounds_dim="bounds")
-    assert mollwds.lat_vertices.equals(lat_c)
+    lat_c = cfxr.bounds_to_vertices(mollwds.lat_bounds, bounds_dim="bounds")
+    assert_equal(mollwds.lat_vertices, lat_c)
 
     # Transposing the array changes the bounds direction
     ds = mollwds.transpose("bounds", "y", "x", "y_vertices", "x_vertices")
-    lon_c = cf.bounds_to_vertices(ds.lon_bounds, bounds_dim="bounds", order="clockwise")
-    lon_c2 = cf.bounds_to_vertices(ds.lon_bounds, bounds_dim="bounds", order=None)
-    assert ds.lon_vertices.equals(lon_c)
-    assert ds.lon_vertices.equals(lon_c2)
+    lon_c = cfxr.bounds_to_vertices(
+        ds.lon_bounds, bounds_dim="bounds", order="clockwise"
+    )
+    lon_c2 = cfxr.bounds_to_vertices(ds.lon_bounds, bounds_dim="bounds", order=None)
+    assert_equal(ds.lon_vertices, lon_c)
+    assert_equal(ds.lon_vertices, lon_c2)
+
+    # Preserves dask-backed arrays
+    if DaskArray is not None:
+        lon_bounds = ds.lon_bounds.chunk()
+        lon_c = cfxr.bounds_to_vertices(
+            lon_bounds, bounds_dim="bounds", order="clockwise"
+        )
+        assert isinstance(lon_c.data, DaskArray)
 
 
 def test_vertices_to_bounds():
     # 1D case
-    ds = airds.cf.add_bounds(["lon", "lat"])
-    lat_c = cf.bounds_to_vertices(ds.lat_bounds, bounds_dim="bounds")
-    lat_b = cf.vertices_to_bounds(lat_c, out_dims=("bounds", "lat"))
+    ds = airds.cf.add_bounds(["lon", "lat", "time"])
+    lat_c = cfxr.bounds_to_vertices(ds.lat_bounds, bounds_dim="bounds")
+    lat_b = cfxr.vertices_to_bounds(lat_c, out_dims=("bounds", "lat"))
     assert_array_equal(ds.lat_bounds, lat_b)
 
+    # Datetime
+    time_c = cfxr.bounds_to_vertices(ds.time_bounds, bounds_dim="bounds")
+    time_b = cfxr.vertices_to_bounds(time_c, out_dims=("bounds", "time"))
+    assert_array_equal(ds.time_bounds, time_b)
+
     # 2D case
-    lon_b = cf.vertices_to_bounds(mollwds.lon_vertices, out_dims=("bounds", "x", "y"))
-    assert (mollwds.lon_bounds == lon_b).all()
+    lon_b = cfxr.vertices_to_bounds(mollwds.lon_vertices, out_dims=("bounds", "x", "y"))
+    assert_array_equal(mollwds.lon_bounds, lon_b)

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -40,9 +40,21 @@ Dataset
     Dataset.cf.decode_vertical_coords
     Dataset.cf.describe
     Dataset.cf.get_bounds
+    Dataset.cf.bounds_to_vertices
     Dataset.cf.standard_names
     Dataset.cf.keys
     Dataset.cf.axes
     Dataset.cf.coordinates
     Dataset.cf.guess_coord_axis
     Dataset.cf.rename_like
+
+.. currentmodule:: cf_xarray
+
+Top-level API
+-------------
+
+.. autosummary::
+    :toctree: generated/
+
+    bounds_to_vertices
+    vertices_to_bounds

--- a/doc/examples/introduction.ipynb
+++ b/doc/examples/introduction.ipynb
@@ -957,6 +957,52 @@
     "ds.air.cf.weighted(\"area\").mean([\"latitude\", \"time\"]).cf.plot(x=\"longitude\")\n",
     "ds.air.mean([\"lat\", \"time\"]).cf.plot(x=\"longitude\")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Feature: Cell boundaries and vertices\n",
+    "\n",
+    "`cf_xarray` can infer cell boundaries (for rectilinear grids) and convert\n",
+    "CF-standard bounds variables to vertices.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds_bnds = ds.cf.add_bounds([\"lat\", \"lon\"])\n",
+    "ds_bnds"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# We can convert each bounds variable independently with the helper:\n",
+    "import cf_xarray as cfxr\n",
+    "\n",
+    "lat_bounds = ds_bnds.cf.get_bounds(\"latitude\")\n",
+    "\n",
+    "lat_vertices = cfxr.bounds_to_vertices(lat_bounds, bounds_dim=\"bounds\")\n",
+    "lat_vertices"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Or we can convert _all_ bounds variables on a dataset\n",
+    "ds_crns = ds_bnds.cf.bounds_to_vertices()\n",
+    "ds_crns"
+   ]
   }
  ],
  "metadata": {
@@ -975,7 +1021,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.8.6"
   },
   "toc": {
    "base_numbering": 1,

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -9,6 +9,8 @@ v0.4.0 (unreleased)
   and changed ``get_valid_keys()`` to ``.keys()``. `Kristen Thyng`_.
 - Added ``.cf.decode_vertical_coords`` for decoding of parameterized vertical coordinate variables.
   (:issue:`34`, :pr:`103`). `Deepak Cherian`_.
+- Added ``cf.get_corners`` to convert from coordinate bounds in a CF format (shape (nx, 2)) to a corners format (shape (nx+1)).
+  (:pr:`108`). `Pascal Bourgault`_.
 
 v0.3.0 (Sep 27, 2020)
 =====================

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -61,6 +61,7 @@ v0.1.3
 - Support expanding key to multiple dimension names.
 
 .. _`Anderson Banihirwe`: https://github.com/andersy005
+.. _`Pascal Bourgault`: https://github.com/aulemahal
 .. _`Deepak Cherian`: https://github.com/dcherian
 .. _`Filipe Fernandes`: https://github.com/ocefpaf
 .. _`Julia Kent`: https://github.com/jukent

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -9,7 +9,8 @@ v0.4.0 (unreleased)
   and changed ``get_valid_keys()`` to ``.keys()``. `Kristen Thyng`_.
 - Added ``.cf.decode_vertical_coords`` for decoding of parameterized vertical coordinate variables.
   (:issue:`34`, :pr:`103`). `Deepak Cherian`_.
-- Added ``cf.get_corners`` to convert from coordinate bounds in a CF format (shape (nx, 2)) to a corners format (shape (nx+1)).
+- Added top-level ``bounds_to_vertices`` and ``vertices_to_bounds`` as well as ``.cf.bounds_to_vertices`` 
+  to convert from coordinate bounds in a CF format (shape (nx, 2)) to a vertices format (shape (nx+1)).
   (:pr:`108`). `Pascal Bourgault`_.
 
 v0.3.0 (Sep 27, 2020)


### PR DESCRIPTION
This PR adds a  `ds.cf.get_corners(key)` method for the Dataset accessor. This method transforms the bounds given in the conventionnal CF format to a "corners" format:

- For grids with 1D coords: `lon_bnds` of shape `(nlon, 2)` becomes `lon_corners` of shape `(nlon + 1)`.
- For grids with 2D coords: `lon_bnds` of shape `(nx, ny, 4)` becomes `lon_corners` of  shape `(nx + 1, ny + 1)`. 

New dimensions are named `{dim}_corners}`.  I added a dataset to the tests with 2D coords and both bounds and corners, it's called "mollwds" cause the (X,Y) -> (lon, lat) transform is a mollweide projection.

Caveats:

- The 2D case is kinda ugly. It is because I found no elegant way of testing if bounds were given in a clockwise or counterclockwise manner. So what that does is compute the clockwise case, verify if it is correct (_for all points_) and, if not, compute the counterclockwise case. Maybe I'm missing something here... 
- This is more a bounds-to-corners conversion function, maybe it could be given as a utility outside the accessor? That way we could also have a corners-to-bounds version.