### PR TITLE
properties now return dictionaries rather than lists

### DIFF
--- a/cf_xarray/accessor.py
+++ b/cf_xarray/accessor.py
@@ -988,8 +988,7 @@ class CFAccessor:
         for k, v in variables.items():
             if "standard_name" in v.attrs:
                 std_name = v.attrs["standard_name"]
-                vardict[std_name] = vardict.setdefault(std_name, [])
-                vardict[std_name] += [k]
+                vardict[std_name] = vardict.setdefault(std_name, []) + [k]
 
         return {k: sorted(v) for k, v in sorted(vardict.items())}
 

--- a/cf_xarray/accessor.py
+++ b/cf_xarray/accessor.py
@@ -991,7 +991,7 @@ class CFAccessor:
                 vardict[std_name] = vardict.setdefault(std_name, [])
                 vardict[std_name] += [k]
 
-        return {k: sorted(v) for k, v in vardict.items()}
+        return {k: sorted(v) for k, v in sorted(vardict.items())}
 
     def get_associated_variable_names(self, name: Hashable) -> Dict[str, List[str]]:
         """

--- a/cf_xarray/accessor.py
+++ b/cf_xarray/accessor.py
@@ -987,10 +987,9 @@ class CFAccessor:
         for k, v in variables.items():
             if "standard_name" in v.attrs:
                 std_name = v.attrs["standard_name"]
-                vardict[std_name] = vardict.setdefault(std_name, [])
-                vardict[std_name] += [k]
+                vardict[std_name] = vardict.setdefault(std_name, []) + [k]
 
-        return {k: sorted(v) for k, v in vardict.items()}
+        return {k: sorted(v) for k, v in sorted(vardict.items())}
 
     def get_associated_variable_names(self, name: Hashable) -> Dict[str, List[str]]:
         """

--- a/cf_xarray/tests/test_accessor.py
+++ b/cf_xarray/tests/test_accessor.py
@@ -33,34 +33,45 @@ def test_describe(capsys):
 
 
 def test_axes():
-    expected = {"T", "X", "Y"}
+    expected = dict(T=["time"], X=["lon"], Y=["lat"])
     actual = airds.cf.axes
     assert actual == expected
 
-    expected = {"X", "Y"}
+    expected = dict(X=["nlon"], Y=["nlat"])
     actual = popds.cf.axes
     assert actual == expected
 
 
 def test_coordinates():
-    expected = {"latitude", "longitude", "time"}
+    expected = dict(latitude=["lat"], longitude=["lon"], time=["time"])
     actual = airds.cf.coordinates
     assert actual == expected
 
-    expected = {"latitude", "longitude"}
+    expected = dict(latitude=["TLAT", "ULAT"], longitude=["TLONG", "ULONG"])
     actual = popds.cf.coordinates
     assert actual == expected
 
 
+def test_cell_measures():
+    expected = dict(area=["cell_area"])
+    actual = airds["air"].cf.cell_measures
+    assert actual == expected
+
+    with pytest.raises(AssertionError, match=r"this only works with DataArrays"):
+        popds.cf.cell_measures
+
+
 def test_standard_names():
-    expected = ["air_temperature", "latitude", "longitude", "time"]
+    expected = dict(
+        air_temperature=["air"], latitude=["lat"], longitude=["lon"], time=["time"]
+    )
     actual = airds.cf.standard_names
     assert actual == expected
 
     dsnew = xr.Dataset()
     dsnew["a"] = ("a", np.arange(10), {"standard_name": "a"})
     dsnew["b"] = ("a", np.arange(10), {"standard_name": "a"})
-    assert dsnew.cf.standard_names == ["a"]
+    assert dsnew.cf.standard_names == dict(a=["a", "b"])
 
 
 def test_getitem_standard_name():

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -4,9 +4,9 @@ What's New
 
 v0.4.0 (unreleased)
 ===================
-- Added ``.axes`` to return available Axis names for an xarray object, ``.coordinates`` for Coordinate names,
-  ``.standard_names`` for standard names, ``.cell_measures`` for cell measures,
-  and changed ``get_valid_keys()`` to ``.keys()``. `Kristen Thyng`_.
+- Added ``.axes`` to return a dictionary mapping available Axis standard names to variable names of an xarray object, ``.coordinates`` for Coordinates, 
+  ``.cell_measures`` for Cell Measures, and ``.standard_names`` for all variables. `Kristen Thyng`_ and `Mattia Almansi`_.
+- Changed ``get_valid_keys()`` to ``.keys()``. `Kristen Thyng`_.
 - Added ``.cf.decode_vertical_coords`` for decoding of parameterized vertical coordinate variables.
   (:issue:`34`, :pr:`103`). `Deepak Cherian`_.
 - Added top-level ``bounds_to_vertices`` and ``vertices_to_bounds`` as well as ``.cf.bounds_to_vertices`` 
@@ -61,6 +61,7 @@ v0.1.3
 
 - Support expanding key to multiple dimension names.
 
+.. _`Mattia Almansi`: https://github.com/malmans2
 .. _`Anderson Banihirwe`: https://github.com/andersy005
 .. _`Pascal Bourgault`: https://github.com/aulemahal
 .. _`Deepak Cherian`: https://github.com/dcherian


### PR DESCRIPTION
Closes #109

`.axes`, `.coordinates`, `.cell_measures`, `.standard_names` return dictionaries mapping standard name to variable names.

`.get_standard_names` still returns a list of standard names.