### PR TITLE
Remove grid_longitude from longitude standard names

### DIFF
--- a/cf_xarray/accessor.py
+++ b/cf_xarray/accessor.py
@@ -75,8 +75,8 @@ coordinate_criteria: MutableMapping[str, MutableMapping[str, Tuple]] = {
             "ocean_sigma_z_coordinate",
             "ocean_double_sigma_coordinate",
         ),
-        "latitude": ("latitude", "grid_latitude"),
-        "longitude": ("longitude", "grid_longitude"),
+        "latitude": ("latitude",),
+        "longitude": ("longitude",),
     },
     "_CoordinateAxisType": {
         "T": ("Time",),


### PR DESCRIPTION
As noted in pangeo-data/xESMF#55 and per CF conventions, it is incorrect to assume a coordinate that has a 'grid_longitude' standard name is indeed a 'longitude' coordinate. For example, this standard name is also used by rotated pole coordinates (usually 'rlon' and 'rlat').
This PR removes the `grid_X` standard names.