### PR TITLE
add support for drop_dims

### DIFF
--- a/cf_xarray/accessor.py
+++ b/cf_xarray/accessor.py
@@ -372,6 +372,7 @@ def _get_with_standard_name(
 _DEFAULT_KEY_MAPPERS: Mapping[str, Tuple[Mapper, ...]] = {
     "dim": (_get_axis_coord,),
     "dims": (_get_axis_coord,),  # transpose
+    "drop_dims": (_get_axis_coord,),  # drop_dims
     "dimensions": (_get_axis_coord,),  # stack
     "dims_dict": (_get_axis_coord,),  # swap_dims, rename_dims
     "shifts": (_get_axis_coord,),  # shift, roll

--- a/cf_xarray/tests/test_accessor.py
+++ b/cf_xarray/tests/test_accessor.py
@@ -708,3 +708,11 @@ def test_drop_sel_and_reset_coords(obj):
         assert_identical(
             obj.reset_coords("air"), obj.cf.reset_coords("air_temperature")
         )
+
+
+@pytest.mark.parametrize("ds", datasets)
+def test_drop_dims(ds):
+
+    # Axis and coordinate
+    for cf_name in ["X", "longitude"]:
+        assert_identical(ds.drop_dims("lon"), ds.cf.drop_dims(cf_name))

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -6,7 +6,7 @@ What's New
 v0.4.1 (unreleased)
 ===================
 
-- Support for ``.drop()``, ``.drop_vars()``, ``.drop_sel()``, ``.set_coords()``, ``.reset_coords()``. By `Mattia Almansi`_.
+- Support for ``.drop()``, ``.drop_vars()``, ``.drop_sel()``, ``.drop_dims()``, ``.set_coords()``, ``.reset_coords()``. By `Mattia Almansi`_.
 - Support for using ``standard_name`` in more functions. (:pr:`128`) By `Deepak Cherian`_
 - Allow ``DataArray.cf[]`` with standard names. By `Deepak Cherian`_
 - Rewrite the ``values`` of ``.cf.coords`` and ``.cf.data_vars`` with objects returned


### PR DESCRIPTION
I forgot about `drop_dims` in #145.