### PR TITLE
add coordinate criteria table in docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,7 +69,9 @@ instance/
 .scrapy
 
 # Sphinx documentation
-docs/_build/
+doc/_build/
+doc/generated/
+cf_xarray/tests/_build/
 
 # PyBuilder
 target/

--- a/cf_xarray/scripts/make_doc.py
+++ b/cf_xarray/scripts/make_doc.py
@@ -4,19 +4,33 @@ import os
 
 from pandas import DataFrame
 
-from cf_xarray.accessor import coordinate_criteria
+from cf_xarray.accessor import _AXIS_NAMES, _COORD_NAMES, coordinate_criteria
 
 
 def main():
 
-    # coordinate_criteria table
-    path = "_build/csv/coordinate_criteria.csv"
-    os.makedirs(os.path.dirname(path), exist_ok=True)
-    df = DataFrame.from_dict(coordinate_criteria)
-    df = df.fillna("")
-    df = df.applymap(lambda x: ", ".join(sorted(x)))
-    df = df.sort_index(0).sort_index(1)
-    df.to_csv(path)
+    # axes, coordinates, and coordinate criteria tables
+    axes = {
+        key: {k: v for k, v in values.items() if k in _AXIS_NAMES}
+        for key, values in coordinate_criteria.items()
+    }
+    coords = {
+        key: {k: v for k, v in values.items() if k in _COORD_NAMES}
+        for key, values in coordinate_criteria.items()
+    }
+
+    for mapper, name in zip(
+        [coordinate_criteria, axes, coords],
+        ["coordinate_criteria", "axes", "coordinates"],
+    ):
+
+        path = f"_build/csv/{name}.csv"
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        df = DataFrame.from_dict(mapper)
+        df = df.fillna("")
+        df = df.applymap(lambda x: ", ".join(sorted(x)))
+        df = df.sort_index(0).sort_index(1)
+        df.to_csv(path)
 
 
 if __name__ == "__main__":

--- a/cf_xarray/scripts/make_doc.py
+++ b/cf_xarray/scripts/make_doc.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+
+import os
+
+from pandas import DataFrame
+
+from cf_xarray.accessor import coordinate_criteria
+
+
+def main():
+
+    # coordinate_criteria table
+    path = "_build/csv/coordinate_criteria.csv"
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    df = DataFrame.from_dict(coordinate_criteria)
+    df = df.fillna("")
+    df = df.applymap(lambda x: ", ".join(sorted(x)))
+    df = df.sort_index(0).sort_index(1)
+    df.to_csv(path)
+
+
+if __name__ == "__main__":
+    main()

--- a/cf_xarray/scripts/make_doc.py
+++ b/cf_xarray/scripts/make_doc.py
@@ -12,11 +12,11 @@ def main():
     Make all additional files needed to build the documentations.
     """
 
-    make_criteria()
-    make_regex()
+    make_criteria_csv()
+    make_regex_csv()
 
 
-def make_criteria():
+def make_criteria_csv():
     """
     Make criteria tables:
         _build/csv/{all,axes,coords}_criteria.csv
@@ -41,10 +41,10 @@ def make_criteria():
         subdf.to_csv(os.path.join(csv_dir, f"{name}_criteria.csv"))
 
 
-def make_regex():
+def make_regex_csv():
     """
     Make regex tables:
-        _build/csv/{axes,coords}_regex.csv
+        _build/csv/all_regex.csv
     """
 
     csv_dir = "_build/csv"

--- a/cf_xarray/tests/test_scripts.py
+++ b/cf_xarray/tests/test_scripts.py
@@ -3,7 +3,8 @@ import os
 from cf_xarray.scripts import make_doc
 
 
-def remove_if_exist(paths):
+def remove_if_exists(paths):
+    paths = [paths] if isinstance(paths, str) else paths
     for path in paths:
         if os.path.exists(path):
             os.remove(path)
@@ -16,11 +17,16 @@ def test_make_doc():
     owd = os.getcwd()
     os.chdir(os.path.dirname(__file__))
     try:
-        names = ["axes", "coordinates", "coordinate_criteria"]
-        paths_to_check = [f"_build/csv/{name}.csv" for name in names]
-        remove_if_exist(paths_to_check)
+        names = [
+            "axes_criteria",
+            "coords_criteria",
+            "all_criteria",
+            "all_regex",
+        ]
+        tables_to_check = [f"_build/csv/{name}.csv" for name in names]
+        remove_if_exists(tables_to_check)
 
         make_doc.main()
-        assert all(os.path.exists(path) for path in paths_to_check)
+        assert all(os.path.exists(path) for path in tables_to_check)
     finally:
         os.chdir(owd)

--- a/cf_xarray/tests/test_scripts.py
+++ b/cf_xarray/tests/test_scripts.py
@@ -1,0 +1,13 @@
+import os
+
+from cf_xarray.scripts import make_doc
+
+
+def test_make_doc():
+
+    path = "_build/csv/coordinate_criteria.csv"
+    try:
+        make_doc.main()
+        assert os.path.exists(path)
+    finally:
+        os.remove(path)

--- a/cf_xarray/tests/test_scripts.py
+++ b/cf_xarray/tests/test_scripts.py
@@ -3,11 +3,24 @@ import os
 from cf_xarray.scripts import make_doc
 
 
+def remove_if_exist(paths):
+    for path in paths:
+        if os.path.exists(path):
+            os.remove(path)
+
+
 def test_make_doc():
 
-    path = "_build/csv/coordinate_criteria.csv"
+    # Create/remove files from tests/,
+    # always return to original working directory
+    owd = os.getcwd()
+    os.chdir(os.path.dirname(__file__))
     try:
+        names = ["axes", "coordinates", "coordinate_criteria"]
+        paths_to_check = [f"_build/csv/{name}.csv" for name in names]
+        remove_if_exist(paths_to_check)
+
         make_doc.main()
-        assert os.path.exists(path)
+        assert all(os.path.exists(path) for path in paths_to_check)
     finally:
-        os.remove(path)
+        os.chdir(owd)

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -18,6 +18,9 @@ import sys
 import sphinx_autosummary_accessors
 
 import cf_xarray  # noqa
+from cf_xarray.scripts import make_doc
+
+make_doc.main()
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the

--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -32,6 +32,11 @@ This dictionary contains criteria for identifying axis and coords using CF attri
 
    ~accessor.coordinate_criteria
 
+.. csv-table::
+   :file: _build/csv/coordinate_criteria.csv
+   :header-rows: 1
+   :stub-columns: 1
+
 Classes
 ~~~~~~~
 

--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -33,7 +33,7 @@ This dictionary contains criteria for identifying axis and coords using CF attri
    ~accessor.coordinate_criteria
 
 .. csv-table::
-   :file: _build/csv/coordinate_criteria.csv
+   :file: _build/csv/all_criteria.csv
    :header-rows: 1
    :stub-columns: 1
 

--- a/doc/criteria.rst
+++ b/doc/criteria.rst
@@ -1,23 +1,34 @@
-.. _criteria:
+.. currentmodule:: xarray
 
 CF Criteria
 -----------
 
+Attributes
+~~~~~~~~~~
 Criteria for identifying variables using CF attributes.
 
 Axes
-~~~~
+====
 
 .. csv-table::
-   :file: _build/csv/axes.csv
+   :file: _build/csv/axes_criteria.csv
    :header-rows: 1
    :stub-columns: 1
 
 Coordinates
-~~~~~~~~~~~
+===========
 
 .. csv-table::
-   :file: _build/csv/coordinates.csv
+   :file: _build/csv/coords_criteria.csv
    :header-rows: 1
+   :stub-columns: 1
+
+
+Names
+~~~~~
+Regex used by :meth:`DataArray.cf.guess_coord_axis` and :meth:`Dataset.cf.guess_coord_axis` for identifying variables using their names.
+
+.. csv-table::
+   :file: _build/csv/all_regex.csv
    :stub-columns: 1
 

--- a/doc/criteria.rst
+++ b/doc/criteria.rst
@@ -1,0 +1,23 @@
+.. _criteria:
+
+CF Criteria
+-----------
+
+Criteria for identifying variables using CF attributes.
+
+Axes
+~~~~
+
+.. csv-table::
+   :file: _build/csv/axes.csv
+   :header-rows: 1
+   :stub-columns: 1
+
+Coordinates
+~~~~~~~~~~~
+
+.. csv-table::
+   :file: _build/csv/coordinates.csv
+   :header-rows: 1
+   :stub-columns: 1
+

--- a/doc/examples/introduction.ipynb
+++ b/doc/examples/introduction.ipynb
@@ -184,7 +184,10 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## What attributes have been discovered?\n"
+    "## What attributes have been discovered?\n",
+    "\n",
+    "The criteria for identifying variables using CF attributes are listed\n",
+    "[here](../criteria.rst).\n"
    ]
   },
   {
@@ -1028,7 +1031,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.8"
+   "version": "3.7.3"
   },
   "toc": {
    "base_numbering": 1,

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -39,6 +39,7 @@ Table of contents
    :maxdepth: 2
 
    examples/introduction
+   criteria
    whats-new
    roadmap
    contributing

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -6,6 +6,7 @@ What's New
 v0.4.1 (unreleased)
 ===================
 
+- Added scripts to document CF criteria with tables. By `Mattia Almansi`_.
 - Support for ``.drop()``, ``.drop_vars()``, ``.drop_sel()``, ``.drop_dims()``, ``.set_coords()``, ``.reset_coords()``. By `Mattia Almansi`_.
 - Support for using ``standard_name`` in more functions. (:pr:`128`) By `Deepak Cherian`_
 - Allow ``DataArray.cf[]`` with standard names. By `Deepak Cherian`_

--- a/setup.cfg
+++ b/setup.cfg
@@ -117,5 +117,5 @@ nobeep = True
 
 [rstcheck]
 ignore_roles=pr,issue
-ignore_directives=ipython,autodata
+ignore_directives=ipython,autodata,csv-table
 ignore_messages=(is not referenced\.$)

--- a/setup.cfg
+++ b/setup.cfg
@@ -116,6 +116,6 @@ test = pytest
 nobeep = True
 
 [rstcheck]
-ignore_roles=pr,issue
+ignore_roles=pr,issue,meth
 ignore_directives=ipython,autodata,csv-table
 ignore_messages=(is not referenced\.$)


### PR DESCRIPTION
Close #138: I'd also find it very useful so I gave it a go.

I've added a script to create a table with coordinate criteria in the documentation.
Not sure if I placed the table and the script in the right place (maybe the *script should just go in `doc/`?), but that should be easy to change.

Right now it creates this.

![attribute_table](https://user-images.githubusercontent.com/22245117/106309462-14c58600-625a-11eb-90a5-450855c345f3.png)
