### PR TITLE
show coords std names

### DIFF
--- a/cf_xarray/accessor.py
+++ b/cf_xarray/accessor.py
@@ -656,7 +656,7 @@ def _getitem(
     except KeyError:
         raise KeyError(
             f"{kind}.cf does not understand the key {k!r}. "
-            f"Use {kind}.cf.describe() to see a list of key names that can be interpreted."
+            f"Use print({kind}.cf) to see a list of key names that can be interpreted."
         )
 
 

--- a/cf_xarray/accessor.py
+++ b/cf_xarray/accessor.py
@@ -967,7 +967,7 @@ class CFAccessor:
 
         text += "\nStandard Names:\n"
         for key, value in sorted(self.standard_names.items()):
-            if key not in _COORD_NAMES:
+            if key not in coords:
                 text += f"\t{key}: {value}\n"
 
         print(text)

--- a/cf_xarray/accessor.py
+++ b/cf_xarray/accessor.py
@@ -950,6 +950,8 @@ class CFAccessor:
         """
         Print a string repr to screen.
         """
+        star = "\t".expandtabs()[:-2] + "* "
+
         text = "Axes:\n"
         axes = self.axes
         for key in _AXIS_NAMES:
@@ -963,11 +965,16 @@ class CFAccessor:
         text += "\nCell Measures:\n"
         measures = self.cell_measures
         for key in sorted(self._get_all_cell_measures()):
-            text += f"\t{key}: {measures[key] if key in measures else []}\n"
+            if key in {**axes, **coords}:
+                text += f"{star}{key}: {measures[key] if key in measures else []}\n"
+            else:
+                text += f"\t{key}: {measures[key] if key in measures else []}\n"
 
         text += "\nStandard Names:\n"
         for key, value in sorted(self.standard_names.items()):
-            if key not in coords:
+            if key in {**axes, **coords, **measures}:
+                text += f"{star}{key}: {value}\n"
+            else:
                 text += f"\t{key}: {value}\n"
 
         print(text)

--- a/cf_xarray/accessor.py
+++ b/cf_xarray/accessor.py
@@ -656,7 +656,7 @@ def _getitem(
     except KeyError:
         raise KeyError(
             f"{kind}.cf does not understand the key {k!r}. "
-            f"Use print({kind}.cf) to see a list of key names that can be interpreted."
+            f"Use 'repr({kind}.cf)' (or '{kind}.cf' in a Jupyter environment) to see a list of key names that can be interpreted."
         )
 
 
@@ -953,10 +953,10 @@ class CFAccessor:
 
         warnings.warn(
             "'obj.cf.describe()' will be removed in a future version. "
-            "Use instead 'print(obj.cf)''",
+            "Use instead 'repr(obj.cf)' or 'obj.cf' in a Jupyter environment.",
             DeprecationWarning,
         )
-        print(self.__repr__())
+        print(repr(self))
 
     def __repr__(self):
 

--- a/cf_xarray/tests/test_accessor.py
+++ b/cf_xarray/tests/test_accessor.py
@@ -1,3 +1,5 @@
+from textwrap import dedent
+
 import matplotlib as mpl
 import numpy as np
 import pandas as pd
@@ -26,20 +28,99 @@ def assert_dicts_identical(dict1, dict2):
         assert_identical(dict1[k], dict2[k])
 
 
-def test_describe(capsys):
-    airds.cf.describe()
-    actual = capsys.readouterr().out
-    expected = (
-        "Axes:\n\tX: ['lon']\n\tY: ['lat']\n\tZ: []\n\tT: ['time']\n"
-        "\nCoordinates:\n\tlongitude: ['lon']\n\tlatitude: ['lat']"
-        "\n\tvertical: []\n\ttime: ['time']\n"
-        "\nCell Measures:\n\tarea: ['cell_area']\n\tvolume: []\n"
-        "\nStandard Names:\n\tair_temperature: ['air']\n"
-        "      * latitude: ['lat']\n"
-        "      * longitude: ['lon']\n"
-        "      * time: ['time']\n\n"
-    )
-    assert actual == expected
+def test_repr():
+    # Dataset.
+    # Stars: axes, coords, and std names
+    actual = airds.cf.__repr__()
+    expected = """\
+    Coordinates:
+      - CF Axes:
+          * X: ['lon']
+          * Y: ['lat']
+          * T: ['time']
+            Z: n/a
+
+      - CF Coordinates:
+          * longitude: ['lon']
+          * latitude: ['lat']
+          * time: ['time']
+            vertical: n/a
+
+      - Cell Measures:
+            area: ['cell_area']
+            volume: n/a
+
+      - Standard Names:
+          * latitude: ['lat']
+          * longitude: ['lon']
+          * time: ['time']
+
+    Data Variables:
+      - Cell Measures:
+            area, volume: n/a
+
+      - Standard Names:
+            air_temperature: ['air']
+    """
+    assert actual == dedent(expected)
+
+    # DataArray (Coordinates section same as Dataset)
+    assert airds.cf.__repr__().startswith(airds["air"].cf.__repr__())
+    actual = airds["air"].cf.__repr__()
+    expected = """\
+    Coordinates:
+      - CF Axes:
+          * X: ['lon']
+          * Y: ['lat']
+          * T: ['time']
+            Z: n/a
+
+      - CF Coordinates:
+          * longitude: ['lon']
+          * latitude: ['lat']
+          * time: ['time']
+            vertical: n/a
+
+      - Cell Measures:
+            area: ['cell_area']
+            volume: n/a
+
+      - Standard Names:
+          * latitude: ['lat']
+          * longitude: ['lon']
+          * time: ['time']
+    """
+    assert actual == dedent(expected)
+
+    # Empty Standard Names
+    actual = popds.cf.__repr__()
+    expected = """\
+    Coordinates:
+      - CF Axes:
+          * X: ['nlon']
+          * Y: ['nlat']
+            T, Z: n/a
+
+      - CF Coordinates:
+            longitude: ['TLONG', 'ULONG']
+            latitude: ['TLAT', 'ULAT']
+            time, vertical: n/a
+
+      - Cell Measures:
+            area, volume: n/a
+
+      - Standard Names:
+            n/a
+
+    Data Variables:
+      - Cell Measures:
+            area, volume: n/a
+
+      - Standard Names:
+            sea_water_x_velocity: ['UVEL']
+            sea_water_potential_temperature: ['TEMP']
+    """
+    assert actual == dedent(expected)
 
 
 def test_axes():
@@ -62,7 +143,7 @@ def test_coordinates():
     assert actual == expected
 
 
-def test_cell_measures(capsys):
+def test_cell_measures():
     ds = airds.copy(deep=True)
     ds["foo"] = xr.DataArray(ds["cell_area"], attrs=dict(standard_name="foo_std_name"))
     ds["air"].attrs["cell_measures"] += " foo_measure: foo"
@@ -78,19 +159,20 @@ def test_cell_measures(capsys):
     actual = ds.cf.cell_measures
     assert actual == expected
 
-    ds.cf.describe()
-    actual = capsys.readouterr().out
-    expected = (
-        "\nCell Measures:\n"
-        "\tarea: ['cell_area']\n\tfoo_measure: ['foo']\n"
-        "\tvolume: ['foo']\n"
-        "\nStandard Names:\n"
-        "\tair_temperature: ['air']\n\tfoo_std_name: ['foo']\n"
-        "      * latitude: ['lat']\n"
-        "      * longitude: ['lon']\n"
-        "      * time: ['time']\n\n"
-    )
-    assert actual.endswith(expected)
+    # Additional cell measure in repr
+    actual = ds.cf.__repr__()
+    expected = """\
+    Data Variables:
+      - Cell Measures:
+            foo_measure: ['foo']
+            volume: ['foo']
+            area: n/a
+
+      - Standard Names:
+            air_temperature: ['air']
+            foo_std_name: ['foo']
+    """
+    assert actual.endswith(dedent(expected))
 
 
 def test_standard_names():

--- a/cf_xarray/tests/test_accessor.py
+++ b/cf_xarray/tests/test_accessor.py
@@ -34,7 +34,10 @@ def test_describe(capsys):
         "\nCoordinates:\n\tlongitude: ['lon']\n\tlatitude: ['lat']"
         "\n\tvertical: []\n\ttime: ['time']\n"
         "\nCell Measures:\n\tarea: ['cell_area']\n\tvolume: []\n"
-        "\nStandard Names:\n\tair_temperature: ['air']\n\n"
+        "\nStandard Names:\n\tair_temperature: ['air']\n"
+        "      * latitude: ['lat']\n"
+        "      * longitude: ['lon']\n"
+        "      * time: ['time']\n\n"
     )
     assert actual == expected
 
@@ -78,8 +81,14 @@ def test_cell_measures(capsys):
     ds.cf.describe()
     actual = capsys.readouterr().out
     expected = (
-        "\nCell Measures:\n\tarea: ['cell_area']\n\tfoo_measure: ['foo']\n\tvolume: ['foo']\n"
-        "\nStandard Names:\n\tair_temperature: ['air']\n\tfoo_std_name: ['foo']\n\n"
+        "\nCell Measures:\n"
+        "\tarea: ['cell_area']\n\tfoo_measure: ['foo']\n"
+        "\tvolume: ['foo']\n"
+        "\nStandard Names:\n"
+        "\tair_temperature: ['air']\n\tfoo_std_name: ['foo']\n"
+        "      * latitude: ['lat']\n"
+        "      * longitude: ['lon']\n"
+        "      * time: ['time']\n\n"
     )
     assert actual.endswith(expected)
 

--- a/cf_xarray/tests/test_accessor.py
+++ b/cf_xarray/tests/test_accessor.py
@@ -34,33 +34,27 @@ def test_repr():
     actual = airds.cf.__repr__()
     expected = """\
     Coordinates:
-      - CF Axes:
-          * X: ['lon']
-          * Y: ['lat']
-          * T: ['time']
-            Z: n/a
+    - CF Axes: * X: ['lon']
+               * Y: ['lat']
+               * T: ['time']
+                 Z: n/a
 
-      - CF Coordinates:
-          * longitude: ['lon']
-          * latitude: ['lat']
-          * time: ['time']
-            vertical: n/a
+    - CF Coordinates: * longitude: ['lon']
+                      * latitude: ['lat']
+                      * time: ['time']
+                        vertical: n/a
 
-      - Cell Measures:
-            area: ['cell_area']
-            volume: n/a
+    - Cell Measures:   area: ['cell_area']
+                       volume: n/a
 
-      - Standard Names:
-          * latitude: ['lat']
-          * longitude: ['lon']
-          * time: ['time']
+    - Standard Names: * latitude: ['lat']
+                      * longitude: ['lon']
+                      * time: ['time']
 
     Data Variables:
-      - Cell Measures:
-            area, volume: n/a
+    - Cell Measures:   area, volume: n/a
 
-      - Standard Names:
-            air_temperature: ['air']
+    - Standard Names:   air_temperature: ['air']
     """
     assert actual == dedent(expected)
 
@@ -69,26 +63,22 @@ def test_repr():
     actual = airds["air"].cf.__repr__()
     expected = """\
     Coordinates:
-      - CF Axes:
-          * X: ['lon']
-          * Y: ['lat']
-          * T: ['time']
-            Z: n/a
+    - CF Axes: * X: ['lon']
+               * Y: ['lat']
+               * T: ['time']
+                 Z: n/a
 
-      - CF Coordinates:
-          * longitude: ['lon']
-          * latitude: ['lat']
-          * time: ['time']
-            vertical: n/a
+    - CF Coordinates: * longitude: ['lon']
+                      * latitude: ['lat']
+                      * time: ['time']
+                        vertical: n/a
 
-      - Cell Measures:
-            area: ['cell_area']
-            volume: n/a
+    - Cell Measures:   area: ['cell_area']
+                       volume: n/a
 
-      - Standard Names:
-          * latitude: ['lat']
-          * longitude: ['lon']
-          * time: ['time']
+    - Standard Names: * latitude: ['lat']
+                      * longitude: ['lon']
+                      * time: ['time']
     """
     assert actual == dedent(expected)
 
@@ -96,29 +86,23 @@ def test_repr():
     actual = popds.cf.__repr__()
     expected = """\
     Coordinates:
-      - CF Axes:
-          * X: ['nlon']
-          * Y: ['nlat']
-            T, Z: n/a
+    - CF Axes: * X: ['nlon']
+               * Y: ['nlat']
+                 Z, T: n/a
 
-      - CF Coordinates:
-            longitude: ['TLONG', 'ULONG']
-            latitude: ['TLAT', 'ULAT']
-            time, vertical: n/a
+    - CF Coordinates:   longitude: ['TLONG', 'ULONG']
+                        latitude: ['TLAT', 'ULAT']
+                        vertical, time: n/a
 
-      - Cell Measures:
-            area, volume: n/a
+    - Cell Measures:   area, volume: n/a
 
-      - Standard Names:
-            n/a
+    - Standard Names:   n/a
 
     Data Variables:
-      - Cell Measures:
-            area, volume: n/a
+    - Cell Measures:   area, volume: n/a
 
-      - Standard Names:
-            sea_water_x_velocity: ['UVEL']
-            sea_water_potential_temperature: ['TEMP']
+    - Standard Names:   sea_water_potential_temperature: ['TEMP']
+                        sea_water_x_velocity: ['UVEL']
     """
     assert actual == dedent(expected)
 
@@ -163,14 +147,11 @@ def test_cell_measures():
     actual = ds.cf.__repr__()
     expected = """\
     Data Variables:
-      - Cell Measures:
-            foo_measure: ['foo']
-            volume: ['foo']
-            area: n/a
+    - Cell Measures:   volume: ['foo']
+                       area: n/a
 
-      - Standard Names:
-            air_temperature: ['air']
-            foo_std_name: ['foo']
+    - Standard Names:   air_temperature: ['air']
+                        foo_std_name: ['foo']
     """
     assert actual.endswith(dedent(expected))
 

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -21,7 +21,7 @@ DataArray
    :template: autosummary/accessor_method.rst
 
     DataArray.cf.__getitem__
-    DataArray.cf.describe
+    DataArray.cf.__repr__
     DataArray.cf.guess_coord_axis
     DataArray.cf.keys
     DataArray.cf.rename_like
@@ -43,10 +43,10 @@ Dataset
    :template: autosummary/accessor_method.rst
 
     DataArray.cf.__getitem__
+    DataArray.cf.__repr__
     Dataset.cf.add_bounds
     Dataset.cf.bounds_to_vertices
     Dataset.cf.decode_vertical_coords
-    Dataset.cf.describe
     Dataset.cf.get_bounds
     Dataset.cf.guess_coord_axis
     Dataset.cf.keys

--- a/doc/examples/introduction.ipynb
+++ b/doc/examples/introduction.ipynb
@@ -213,7 +213,7 @@
     "\n",
     "It can also use the `standard_name` and `units` attributes to infer that `lon`\n",
     "is \"Longitude\". To see variable names that `cf_xarray` can infer, use\n",
-    "`.cf.describe()`\n"
+    "`print(ds.cf)`\n"
    ]
   },
   {
@@ -227,7 +227,7 @@
    },
    "outputs": [],
    "source": [
-    "ds.cf.describe()"
+    "ds.cf"
    ]
   },
   {
@@ -250,7 +250,7 @@
    },
    "outputs": [],
    "source": [
-    "pop.cf.describe()"
+    "pop.cf"
    ]
   },
   {
@@ -271,7 +271,7 @@
    },
    "outputs": [],
    "source": [
-    "multiple.cf.describe()"
+    "multiple.cf"
    ]
   },
   {

--- a/doc/examples/introduction.ipynb
+++ b/doc/examples/introduction.ipynb
@@ -212,8 +212,7 @@
     "`'X'` axis as being represented by the `lon` variable.\n",
     "\n",
     "It can also use the `standard_name` and `units` attributes to infer that `lon`\n",
-    "is \"Longitude\". To see variable names that `cf_xarray` can infer, use\n",
-    "`print(ds.cf)`\n"
+    "is \"Longitude\". To see variable names that `cf_xarray` can infer, use `ds.cf`\n"
    ]
   },
   {

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -6,7 +6,7 @@ What's New
 v0.4.1 (unreleased)
 ===================
 
-- Replace ``cf.describe`` with :py:meth:`DataArray.cf.__repr__` and :py:meth:`Dataset.cf.__repr__`. By `Mattia Almansi`_.
+- Replace ``cf.describe`` with :py:meth:`Dataset.cf.__repr__`. By `Mattia Almansi`_.
 - Added scripts to document CF criteria with tables. By `Mattia Almansi`_.
 - Support for ``.drop()``, ``.drop_vars()``, ``.drop_sel()``, ``.drop_dims()``, ``.set_coords()``, ``.reset_coords()``. By `Mattia Almansi`_.
 - Support for using ``standard_name`` in more functions. (:pr:`128`) By `Deepak Cherian`_

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -6,6 +6,7 @@ What's New
 v0.4.1 (unreleased)
 ===================
 
+- Replace ``cf.describe`` with :py:meth:`DataArray.cf.__repr__` and :py:meth:`Dataset.cf.__repr__`. By `Mattia Almansi`_.
 - Added scripts to document CF criteria with tables. By `Mattia Almansi`_.
 - Support for ``.drop()``, ``.drop_vars()``, ``.drop_sel()``, ``.drop_dims()``, ``.set_coords()``, ``.reset_coords()``. By `Mattia Almansi`_.
 - Support for using ``standard_name`` in more functions. (:pr:`128`) By `Deepak Cherian`_

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -6,7 +6,7 @@ What's New
 v0.4.1 (unreleased)
 ===================
 
-- Replace ``cf.describe`` with :py:meth:`Dataset.cf.__repr__`. By `Mattia Almansi`_.
+- Replace ``cf.describe()`` with :py:meth:`Dataset.cf.__repr__`. By `Mattia Almansi`_.
 - Added scripts to document CF criteria with tables. By `Mattia Almansi`_.
 - Support for ``.drop()``, ``.drop_vars()``, ``.drop_sel()``, ``.drop_dims()``, ``.set_coords()``, ``.reset_coords()``. By `Mattia Almansi`_.
 - Support for using ``standard_name`` in more functions. (:pr:`128`) By `Deepak Cherian`_


### PR DESCRIPTION
Tiny change.
In this case:
```python
from cf_xarray.tests.datasets import airds
airds.rename_dims(lon="x", lat="y").reset_coords().cf.describe()
```
currently `longitude` and `latitude` are not shown by `.describe()`.
This change shows them in the Standard Names section.