### PR TITLE
Add "get_bounds_dim_name"

### DIFF
--- a/cf_xarray/accessor.py
+++ b/cf_xarray/accessor.py
@@ -1374,6 +1374,27 @@ class CFDatasetAccessor(CFAccessor):
         obj = self._maybe_to_dataset()
         return obj[bounds]
 
+    def get_bounds_dim_name(self, key: str) -> str:
+        """
+        Get bounds dim name for variable corresponding to key.
+
+        Parameters
+        ----------
+        key : str
+            Name of variable whose bounds dimension name is desired.
+
+        Returns
+        -------
+        str
+        """
+        crd = self[key]
+        bounds = self.get_bounds(key)
+        bounds_dims = set(bounds.dims) - set(crd.dims)
+        assert len(bounds_dims) == 1
+        bounds_dim = bounds_dims.pop()
+        assert self._obj.sizes[bounds_dim] in [2, 4]
+        return bounds_dim
+
     def add_bounds(self, dims: Union[Hashable, Iterable[Hashable]]):
         """
         Returns a new object with bounds variables. The bounds values are guessed assuming

--- a/cf_xarray/tests/test_accessor.py
+++ b/cf_xarray/tests/test_accessor.py
@@ -9,7 +9,16 @@ from xarray.testing import assert_allclose, assert_identical
 
 import cf_xarray  # noqa
 
-from ..datasets import airds, anc, ds_no_attrs, forecast, multiple, popds, romsds
+from ..datasets import (
+    airds,
+    anc,
+    ds_no_attrs,
+    forecast,
+    mollwds,
+    multiple,
+    popds,
+    romsds,
+)
 from . import raise_if_dask_computes
 
 mpl.use("Agg")
@@ -520,6 +529,15 @@ def test_bounds_to_vertices():
     ds = airds.cf.add_bounds("time")
     dsc = ds.cf.bounds_to_vertices()
     assert "time_bounds" in dsc
+
+
+def test_get_bounds_dim_name():
+    ds = airds.copy(deep=True).cf.add_bounds("lat")
+    assert ds.cf.get_bounds_dim_name("latitude") == "bounds"
+    assert ds.cf.get_bounds_dim_name("lat") == "bounds"
+
+    assert mollwds.cf.get_bounds_dim_name("longitude") == "bounds"
+    assert mollwds.cf.get_bounds_dim_name("lon") == "bounds"
 
 
 def test_docstring():

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -81,6 +81,7 @@ Methods
     Dataset.cf.decode_vertical_coords
     Dataset.cf.describe
     Dataset.cf.get_bounds
+    Dataset.cf.get_bounds_dim_name
     Dataset.cf.guess_coord_axis
     Dataset.cf.keys
     Dataset.cf.rename_like

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -15,6 +15,7 @@ v0.4.1 (unreleased)
   by :py:meth:`Dataset.cf.__getitem__`. This allows extraction of DataArrays when there are clashes
   between DataArray names and "special" CF names like ``T``.
   (:issue:`129`, :pr:`130`). By `Deepak Cherian`_
+- Retrieve bounds dimension name with :py:attr:`Dataset.cf.get_bounds_dim_name`. By `Pascal Bourgault`_.
 
 v0.4.0 (Jan 22, 2021)
 =====================

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -15,7 +15,7 @@ v0.4.1 (unreleased)
   by :py:meth:`Dataset.cf.__getitem__`. This allows extraction of DataArrays when there are clashes
   between DataArray names and "special" CF names like ``T``.
   (:issue:`129`, :pr:`130`). By `Deepak Cherian`_
-- Retrieve bounds dimension name with :py:attr:`Dataset.cf.get_bounds_dim_name`. By `Pascal Bourgault`_.
+- Retrieve bounds dimension name with :py:meth:`Dataset.cf.get_bounds_dim_name`. By `Pascal Bourgault`_.
 
 v0.4.0 (Jan 22, 2021)
 =====================


### PR DESCRIPTION
Fixes (partially) pangeo-data/xESMF#72.

Simple method, practically a copy of code suggested by @dcherian, to get the "bounds" dimension name for a given key.