### PR TITLE
fix cell measures __repr__

### DIFF
--- a/cf_xarray/accessor.py
+++ b/cf_xarray/accessor.py
@@ -1010,15 +1010,19 @@ class CFAccessor:
         coords = self._obj.coords
         dims = self._obj.dims
 
-        def make_text_section(subtitle, vardict, valid_values, valid_keys=None):
+        def make_text_section(subtitle, vardict, valid_values, default_keys=None):
 
             star = " * "
             tab = len(star) * " "
             subtitle = f"- {subtitle}:"
 
-            # Sort keys: Valid keys + additional in alphabetical order
-            valid_keys = [] if not valid_keys else list(valid_keys)
-            ordered_keys = valid_keys + sorted(set(vardict) - set(valid_keys))
+            # Sort keys: Order alphabetically if extra keys are available,
+            # otherwise preserve default keys order
+            default_keys = [] if not default_keys else list(default_keys)
+            extra_keys = list(set(vardict) - set(default_keys))
+            ordered_keys = (
+                sorted(default_keys + extra_keys) if extra_keys else default_keys
+            )
             vardict = {key: vardict[key] for key in ordered_keys if key in vardict}
 
             # Keep only valid values (e.g., coords or data_vars)
@@ -1035,8 +1039,8 @@ class CFAccessor:
             ]
 
             # Add valid keys missing followed by n/a
-            if valid_keys:
-                missing_keys = [key for key in valid_keys if key not in vardict]
+            if default_keys:
+                missing_keys = [key for key in default_keys if key not in vardict]
                 if missing_keys:
                     rows += [tab + ", ".join(missing_keys) + ": n/a"]
             elif not rows:

--- a/cf_xarray/accessor.py
+++ b/cf_xarray/accessor.py
@@ -1016,13 +1016,10 @@ class CFAccessor:
             tab = len(star) * " "
             subtitle = f"- {subtitle}:"
 
-            # Sort keys
-            if not valid_keys:
-                # Alphabetical order
-                vardict = {key: vardict[key] for key in sorted(vardict)}
-            else:
-                # Hardcoded order
-                vardict = {key: vardict[key] for key in valid_keys if key in vardict}
+            # Sort keys: Valid keys + additional in alphabetical order
+            valid_keys = [] if not valid_keys else list(valid_keys)
+            ordered_keys = valid_keys + sorted(set(vardict) - set(valid_keys))
+            vardict = {key: vardict[key] for key in ordered_keys if key in vardict}
 
             # Keep only valid values (e.g., coords or data_vars)
             vardict = {

--- a/cf_xarray/accessor.py
+++ b/cf_xarray/accessor.py
@@ -1016,13 +1016,11 @@ class CFAccessor:
             tab = len(star) * " "
             subtitle = f"- {subtitle}:"
 
-            # Sort keys: Order alphabetically if extra keys are available,
-            # otherwise preserve default keys order
+            # Sort keys if there aren't extra keys,
+            # preserve default keys order otherwise.
             default_keys = [] if not default_keys else list(default_keys)
             extra_keys = list(set(vardict) - set(default_keys))
-            ordered_keys = (
-                sorted(default_keys + extra_keys) if extra_keys else default_keys
-            )
+            ordered_keys = sorted(vardict) if extra_keys else default_keys
             vardict = {key: vardict[key] for key in ordered_keys if key in vardict}
 
             # Keep only valid values (e.g., coords or data_vars)
@@ -1038,7 +1036,7 @@ class CFAccessor:
                 for key, value in vardict.items()
             ]
 
-            # Add valid keys missing followed by n/a
+            # Append missing default keys followed by n/a
             if default_keys:
                 missing_keys = [key for key in default_keys if key not in vardict]
                 if missing_keys:

--- a/cf_xarray/tests/test_accessor.py
+++ b/cf_xarray/tests/test_accessor.py
@@ -156,8 +156,8 @@ def test_cell_measures():
     actual = ds.cf.__repr__()
     expected = """\
     Data Variables:
-    - Cell Measures:   volume: ['foo']
-                       foo_measure: ['foo']
+    - Cell Measures:   foo_measure: ['foo']
+                       volume: ['foo']
                        area: n/a
 
     - Standard Names:   air_temperature: ['air']

--- a/cf_xarray/tests/test_accessor.py
+++ b/cf_xarray/tests/test_accessor.py
@@ -157,6 +157,7 @@ def test_cell_measures():
     expected = """\
     Data Variables:
     - Cell Measures:   volume: ['foo']
+                       foo_measure: ['foo']
                        area: n/a
 
     - Standard Names:   air_temperature: ['air']


### PR DESCRIPTION
Oops sorry, I made a mistake in #150 .
Additional cell measures were not shown in `__repr__`.

Default measures (area and volume) are now shown first, then additional measures are shown in alphabetical order.
The n/a row only applies to area and volume.