### PR TITLE
Add NEMO regex

### DIFF
--- a/cf_xarray/accessor.py
+++ b/cf_xarray/accessor.py
@@ -118,7 +118,7 @@ coordinate_criteria["long_name"] = coordinate_criteria["standard_name"]
 regex = {
     "time": "\\bt\\b|(time|min|hour|day|week|month|year)[0-9]*",
     "vertical": (
-        "\\bz\\b|(nav_lev|gdep|lv_|bottom_top|sigma|h(ei)?ght|altitude|depth|"
+        "(z|nav_lev|gdep|lv_|bottom_top|sigma|h(ei)?ght|altitude|depth|"
         "isobaric|pres|isotherm)[a-z_]*[0-9]*"
     ),
     "Y": "y",

--- a/cf_xarray/accessor.py
+++ b/cf_xarray/accessor.py
@@ -118,13 +118,13 @@ coordinate_criteria["long_name"] = coordinate_criteria["standard_name"]
 regex = {
     "time": "\\bt\\b|time[0-9]*|min|hour|day|week|month|year",
     "vertical": (
-        "\\bz\\b|[a-z_]*[0-9]*_lev|(gdep|lv_|bottom_top|sigma|h(ei)?ght|altitude|depth|isobaric|pres|"
-        "isotherm)[a-z_]*[0-9]*"
+        "\\bz\\b|(nav_)?(lev|gdep|lv_|bottom_top|sigma|h(ei)?ght|altitude|depth|"
+        "isobaric|pres|isotherm)[a-z_]*[0-9]*"
     ),
     "Y": "y",
-    "latitude": "(y?(lat|gphi)[a-z0-9]*)|[a-z0-9]*_lat",
+    "latitude": "(y|nav_)?(lat|gphi)[a-z0-9]*",
     "X": "x",
-    "longitude": "(x?(lon|glam)[a-z0-9]*)|[a-z0-9]*_lon",
+    "longitude": "(x|nav_)?(lon|glam)[a-z0-9]*",
 }
 regex["Z"] = regex["vertical"]
 regex["T"] = regex["time"]

--- a/cf_xarray/accessor.py
+++ b/cf_xarray/accessor.py
@@ -116,15 +116,15 @@ coordinate_criteria["long_name"] = coordinate_criteria["standard_name"]
 
 #: regular expressions for guess_coord_axis
 regex = {
-    "time": "(\\bt\\b|time|min|hour|day|week|month|year)[0-9]*",
+    "time": "\\bt\\b|(time|min|hour|day|week|month|year)[0-9]*",
     "vertical": (
-        "\\bz\\b|(nav_)?(lev|gdep|lv_|bottom_top|sigma|h(ei)?ght|altitude|depth|"
+        "\\bz\\b|(nav_lev|gdep|lv_|bottom_top|sigma|h(ei)?ght|altitude|depth|"
         "isobaric|pres|isotherm)[a-z_]*[0-9]*"
     ),
     "Y": "y",
-    "latitude": "(y|nav_)?(lat|gphi)[a-z0-9]*",
+    "latitude": "y?(nav_lat|lat|gphi)[a-z0-9]*",
     "X": "x",
-    "longitude": "(x|nav_)?(lon|glam)[a-z0-9]*",
+    "longitude": "x?(nav_lon|lon|glam)[a-z0-9]*",
 }
 regex["Z"] = regex["vertical"]
 regex["T"] = regex["time"]

--- a/cf_xarray/accessor.py
+++ b/cf_xarray/accessor.py
@@ -118,7 +118,7 @@ coordinate_criteria["long_name"] = coordinate_criteria["standard_name"]
 regex = {
     "time": "\\bt\\b|time[0-9]*|min|hour|day|week|month|year",
     "vertical": (
-        "\\bz\\b|(gdep|lv_|bottom_top|sigma|h(ei)?ght|altitude|depth|isobaric|pres|"
+        "\\bz\\b|[a-z_]*[0-9]*_lev|(gdep|lv_|bottom_top|sigma|h(ei)?ght|altitude|depth|isobaric|pres|"
         "isotherm)[a-z_]*[0-9]*"
     ),
     "Y": "y",

--- a/cf_xarray/accessor.py
+++ b/cf_xarray/accessor.py
@@ -116,15 +116,15 @@ coordinate_criteria["long_name"] = coordinate_criteria["standard_name"]
 
 #: regular expressions for guess_coord_axis
 regex = {
-    "time": "time[0-9]*|min|hour|day|week|month|year",
+    "time": "\\bt\\b|time[0-9]*|min|hour|day|week|month|year",
     "vertical": (
-        "(lv_|bottom_top|sigma|h(ei)?ght|altitude|depth|isobaric|pres|"
+        "\\bz\\b|(gdep|lv_|bottom_top|sigma|h(ei)?ght|altitude|depth|isobaric|pres|"
         "isotherm)[a-z_]*[0-9]*"
     ),
     "Y": "y",
-    "latitude": "y?lat[a-z0-9]*",
+    "latitude": "(y?(lat|gphi)[a-z0-9]*)|[a-z0-9]*_lat",
     "X": "x",
-    "longitude": "x?lon[a-z0-9]*",
+    "longitude": "(x?(lon|glam)[a-z0-9]*)|[a-z0-9]*_lon",
 }
 regex["Z"] = regex["vertical"]
 regex["T"] = regex["time"]

--- a/cf_xarray/tests/test_accessor.py
+++ b/cf_xarray/tests/test_accessor.py
@@ -629,13 +629,13 @@ def test_docstring():
 
 
 def _make_names(prefixes):
-    suffixes = ["", "a", "_a", "0", "_0"]
+    suffixes = ["", "a", "_a", "0", "_0", "a_0a"]
     return [
         f"{prefix}{suffix}" for prefix, suffix in itertools.product(prefixes, suffixes)
     ]
 
 
-_TIME_NAMES = _make_names(
+_TIME_NAMES = ["t"] + _make_names(
     [
         "time",
         "min",
@@ -646,7 +646,7 @@ _TIME_NAMES = _make_names(
         "year",
     ]
 )
-_VERTICAL_NAMES = _make_names(
+_VERTICAL_NAMES = ["z"] + _make_names(
     [
         "lv_1",
         "bottom_top",
@@ -659,13 +659,15 @@ _VERTICAL_NAMES = _make_names(
         "isobaric",
         "pressure",
         "isotherm",
+        "gdep",
+        "nav_lev",
     ]
 )
 _X_NAMES = _make_names(["x"])
 _Y_NAMES = _make_names(["y"])
 _Z_NAMES = _VERTICAL_NAMES
-_LATITUDE_NAMES = _make_names(["lat", "latitude"])
-_LONGITUDE_NAMES = _make_names(["lon", "longitude"])
+_LATITUDE_NAMES = _make_names(["lat", "latitude", "gphi", "nav_lat"])
+_LONGITUDE_NAMES = _make_names(["lon", "longitude", "glam", "nav_lon"])
 
 
 @pytest.mark.parametrize(

--- a/cf_xarray/tests/test_accessor.py
+++ b/cf_xarray/tests/test_accessor.py
@@ -646,8 +646,9 @@ _TIME_NAMES = ["t"] + _make_names(
         "year",
     ]
 )
-_VERTICAL_NAMES = ["z"] + _make_names(
+_VERTICAL_NAMES = _make_names(
     [
+        "z",
         "lv_1",
         "bottom_top",
         "sigma",


### PR DESCRIPTION
NEMO domain files often don't have attributes, I've added a few regex that should allow to guess most of the axes/coords:

- T, time: `t`, `time_{counter,instant,centered}`
- Z, vertical: `z`, `nav_lev`, `gdep{t,u,v,f,w,uw,vw}_{0,1d}`, `depth{t,u,v,f,w,uw,vw}`
- longitude: `nav_lon`, `glam{t,u,v,f}`
- latitude: `nav_lat`, `gphi{t,u,v,f}`
