### PR TITLE
Rework mappers to be more general

### DIFF
--- a/cf_xarray/accessor.py
+++ b/cf_xarray/accessor.py
@@ -1138,7 +1138,7 @@ class CFAccessor:
 
         This is useful for checking whether a key is valid for indexing, i.e.
         that the attributes necessary to allow indexing by that key exist.
-        However, it will only return the Axis names, not Coordinate names.
+        However, it will only return the Axis names present in ``.coords``, not Coordinate names.
 
         Returns
         -------
@@ -1157,7 +1157,7 @@ class CFAccessor:
 
         This is useful for checking whether a key is valid for indexing, i.e.
         that the attributes necessary to allow indexing by that key exist.
-        However, it will only return the Coordinate names, not Axis names.
+        However, it will only return the Coordinate names present in ``.coords``, not Axis names.
 
         Returns
         -------

--- a/cf_xarray/accessor.py
+++ b/cf_xarray/accessor.py
@@ -208,20 +208,10 @@ def apply_mapper(
     return results
 
 
-def _set_doc(doc):
-    def decorator(func):
-        @functools.wraps(func)
-        def wrapper(*args, **kwargs):
-            return func(*args, **kwargs)
-
-        wrapper.__doc__ = doc
-        return cast(F, wrapper)
-
-    return decorator
-
-
-@_set_doc("Time variable accessor e.g. 'T.month'")
 def _get_groupby_time_accessor(var: Union[DataArray, Dataset], key: str) -> List[str]:
+    """
+    Time variable accessor e.g. 'T.month'
+    """
     """
     Helper method for when our key name is of the nature "T.month" and we want to
     isolate the "T" for coordinate mapping
@@ -241,6 +231,7 @@ def _get_groupby_time_accessor(var: Union[DataArray, Dataset], key: str) -> List
     -----
     Returns an empty list if there is no frequency extension specified.
     """
+
     if "." in key:
         key, ext = key.split(".", 1)
 
@@ -366,28 +357,37 @@ def _get_with_standard_name(
     return varnames
 
 
-@_set_doc(
-    f"One or more of {(_AXIS_NAMES + _COORD_NAMES + _CELL_MEASURES)!r},"
-    "\n\t\t\tor arbitraty measures, or standard names"
-)
 def _get_all(obj: Union[DataArray, Dataset], key: str) -> List[str]:
+    """
+    One or more of ('X', 'Y', 'Z', 'T', 'longitude', 'latitude', 'vertical', 'time',
+    'area', 'volume'), or arbitraty measures, or standard names
+    """
     all_mappers = (_get_axis_coord, _get_measure, _get_with_standard_name)
     results = apply_mapper(all_mappers, obj, key, error=False, default=None)
     return results
 
 
-@_set_doc(_get_all.__doc__ + " present in .dims")
 def _get_dims(obj: Union[DataArray, Dataset], key: str) -> List[str]:
+    """
+    One or more of ('X', 'Y', 'Z', 'T', 'longitude', 'latitude', 'vertical', 'time',
+    'area', 'volume'), or arbitraty measures, or standard names present in .dims
+    """
     return [k for k in _get_all(obj, key) if k in obj.dims]
 
 
-@_set_doc(_get_all.__doc__ + " present in .indexes")
 def _get_indexes(obj: Union[DataArray, Dataset], key: str) -> List[str]:
+    """
+    One or more of ('X', 'Y', 'Z', 'T', 'longitude', 'latitude', 'vertical', 'time',
+    'area', 'volume'), or arbitraty measures, or standard names present in .indexes
+    """
     return [k for k in _get_all(obj, key) if k in obj.indexes]
 
 
-@_set_doc(_get_all.__doc__ + " present in .coords")
 def _get_coords(obj: Union[DataArray, Dataset], key: str) -> List[str]:
+    """
+    One or more of ('X', 'Y', 'Z', 'T', 'longitude', 'latitude', 'vertical', 'time',
+    'area', 'volume'), or arbitraty measures, or standard names present in .coords
+    """
     return [k for k in _get_all(obj, key) if k in obj.coords]
 
 
@@ -830,7 +830,7 @@ class _CFWrappedPlotMethods:
             obj=self._obj.plot,
             attr=attr,
             accessor=self.accessor,
-            key_mappers=dict.fromkeys(self._keys, (_single(_get_coords),)),
+            key_mappers=dict.fromkeys(self._keys, (_single(_get_all),)),
             # TODO: "extra_decorator" is more complex than I would like it to be.
             # Not sure if there is a better way though
             extra_decorator=self._plot_decorator,
@@ -992,8 +992,6 @@ class CFAccessor:
         for vkw in var_kws:
             if vkw in kwargs:
                 maybe_update = {
-                    # TODO: this is assuming key_mappers[k] is always
-                    # _single(_get_all)
                     k: apply_mapper(
                         key_mappers[k], self._obj, v, error=False, default=[v]
                     )[0]

--- a/cf_xarray/accessor.py
+++ b/cf_xarray/accessor.py
@@ -173,7 +173,7 @@ def apply_mapper(
         try:
             results = mapper(obj, key)
         except KeyError as e:
-            if error:
+            if error or "I expected only one." in repr(e):
                 raise e
             else:
                 results = []

--- a/cf_xarray/accessor.py
+++ b/cf_xarray/accessor.py
@@ -1337,12 +1337,7 @@ class CFAccessor:
         ourkeys = self.keys()
         theirkeys = other.cf.keys()
 
-        good_keys = set(_COORD_NAMES) & ourkeys & theirkeys
-        if not good_keys:
-            raise ValueError(
-                "No common coordinate variables between these two objects."
-            )
-
+        good_keys = ourkeys & theirkeys
         renamer = {}
         for key in good_keys:
             ours = _single(_get_all)(self._obj, key)[0]

--- a/cf_xarray/accessor.py
+++ b/cf_xarray/accessor.py
@@ -814,7 +814,7 @@ class _CFWrappedPlotMethods:
             obj=self._obj,
             attr="plot",
             accessor=self.accessor,
-            key_mappers=dict.fromkeys(self._keys, (_single(_get_all),)),
+            key_mappers=dict.fromkeys(self._keys, (_single(_get_coords),)),
         )
         return self._plot_decorator(plot)(*args, **kwargs)
 

--- a/cf_xarray/accessor.py
+++ b/cf_xarray/accessor.py
@@ -424,29 +424,43 @@ def _get_with_standard_name(
     return varnames
 
 
+def _get_all(obj: Union[DataArray, Dataset], key: Union[str, List[str]]) -> List[str]:
+    all_mappers = (_get_axis_coord, _get_measure, _get_with_standard_name, _get_measure)
+    results = apply_mapper(all_mappers, obj, key, error=False, default=None)
+    return results
+
+
+def _get_dims(obj: Union[DataArray, Dataset], key: Union[str, List[str]]):
+    return [k for k in _get_all(obj, key) if k in obj.dims]
+
+
+def _get_indexes(obj: Union[DataArray, Dataset], key: Union[str, List[str]]):
+    return [k for k in _get_all(obj, key) if k in obj.indexes]
+
+
+def _get_coords(obj: Union[DataArray, Dataset], key: Union[str, List[str]]):
+    return [k for k in _get_all(obj, key) if k in obj.coords]
+
+
 #: Default mappers for common keys.
 _DEFAULT_KEY_MAPPERS: Mapping[str, Tuple[Mapper, ...]] = {
-    "dim": (_get_dims,),
-    "dims": (_get_dims,),  # transpose
+    "dim": (_get_dims,),  # (_get_axis_coord, _get_with_standard_name),
+    "dims": (_get_dims,),  # (_get_axis_coord, _get_with_standard_name),  # transpose
     "drop_dims": (_get_dims,),  # drop_dims
     "dimensions": (_get_dims,),  # stack
     "dims_dict": (_get_dims,),  # swap_dims, rename_dims
     "shifts": (_get_dims,),  # shift, roll
     "pad_width": (_get_dims,),  # shift, roll
     "names": (_get_all,),  # set_coords, reset_coords, drop_vars
-    "labels": (_get_all,),  # drop
-    "coords": (_get_coords,),  # interp
+    "labels": (_get_indexes,),  # drop_sel
+    "coords": (_get_dims,),  # interp
     "indexers": (_get_indexes,),  # sel, isel, reindex
     # "indexes": (_get_axis_coord,),  # set_index
-    "dims_or_levels": (_get_indexes,),  # reset_index
+    "dims_or_levels": (_get_dims,),  # reset_index
     "window": (_get_dims,),  # rolling_exp
-    "coord": (_get_coords,),  # differentiate, integrate
-    "group": (
-        _get_axis_coord_single,
-        _get_groupby_time_accessor,
-        _get_with_standard_name,
-    ),
-    "indexer": (_get_single_index,),  # resample
+    "coord": (_get_axis_coord_single,),  # differentiate, integrate
+    "group": (_get_all, _get_groupby_time_accessor),  # groupby
+    "indexer": (_get_indexes,),  # resample
     "variables": (_get_all,),  # sortby
     "weights": (_get_measure_variable,),  # type: ignore
     "chunks": (_get_dims,),  # chunk
@@ -478,6 +492,9 @@ def _build_docstring(func):
     can be used for arguments.
     """
 
+    get_all_docstring = (
+        f"One or more of {(_AXIS_NAMES + _COORD_NAMES)!r};\n\t\t\tor standard names"
+    )
     # this list will need to be updated any time a new mapper is added
     mapper_docstrings = {
         _get_axis_coord: f"One or more of {(_AXIS_NAMES + _COORD_NAMES)!r}",
@@ -485,6 +502,10 @@ def _build_docstring(func):
         _get_groupby_time_accessor: "Time variable accessor e.g. 'T.month'",
         _get_with_standard_name: "Standard names",
         _get_measure_variable: f"One of {_CELL_MEASURES!r}",
+        _get_all: get_all_docstring,
+        _get_indexes: get_all_docstring + "present in .indexes",
+        _get_dims: get_all_docstring + "present in .dims",
+        _get_coords: get_all_docstring + "present in .coords",
     }
 
     sig = inspect.signature(func)
@@ -1421,6 +1442,12 @@ class CFAccessor:
                         )
                     obj[var].attrs = dict(ChainMap(obj[var].attrs, ATTRS[axis]))
         return obj
+
+    def drop(self, *args, **kwargs):
+        raise NotImplementedError(
+            "cf-xarray does not support .drop."
+            "Please use .cf.drop_vars or .cf.drop_sel as appropriate."
+        )
 
 
 @xr.register_dataset_accessor("cf")

--- a/cf_xarray/accessor.py
+++ b/cf_xarray/accessor.py
@@ -436,7 +436,7 @@ _DEFAULT_KEY_MAPPERS: Mapping[str, Tuple[Mapper, ...]] = {
     "labels": (_get_indexes,),  # drop_sel
     "coords": (_get_dims,),  # interp
     "indexers": (_get_dims,),  # sel, isel, reindex
-    "indexes": (_get_dims,),  # set_index TODO: cf_xarray decodes keys, not values
+    #  "indexes": (_single(_get_dims),),  # set_index this decodes keys but not values
     "dims_or_levels": (_get_dims,),  # reset_index
     "window": (_get_dims,),  # rolling_exp
     "coord": (_single(_get_coords),),  # differentiate, integrate

--- a/cf_xarray/accessor.py
+++ b/cf_xarray/accessor.py
@@ -315,42 +315,6 @@ def _get_axis_coord(
     return list(results)
 
 
-def _get_all(var: Union[DataArray, Dataset], key: str) -> List[str]:
-
-    results = set(_get_axis_coord(var, key, error=False))
-    for func in (_get_measure, _get_with_standard_name):
-        results.update(func(var, key))
-
-    return list(results)
-
-
-def _get_dims(var: Union[DataArray, Dataset], key: str) -> List[str]:
-    results = set(_get_all(var, key)).intersection(var.dims)
-    return list(results)
-
-
-def _get_single_dim(var: Union[DataArray, Dataset], key: str) -> List[str]:
-    return _get_single(var, key, _get_dims)
-
-
-def _get_coords(var: Union[DataArray, Dataset], key: str) -> List[str]:
-    results = set(_get_all(var, key)).intersection(var.coords)
-    return list(results)
-
-
-def _get_single_coord(var: Union[DataArray, Dataset], key: str) -> List[str]:
-    return _get_single(var, key, _get_coords)
-
-
-def _get_indexes(var: Union[DataArray, Dataset], key: str) -> List[str]:
-    results = set(_get_all(var, key)).intersection(var.indexes)
-    return list(results)
-
-
-def _get_single_index(var: Union[DataArray, Dataset], key: str) -> List[str]:
-    return _get_single(var, key, _get_indexes)
-
-
 def _get_single(var: Union[DataArray, Dataset], key: str, func):
 
     results = func(var, key)
@@ -424,28 +388,28 @@ def _get_with_standard_name(
     return varnames
 
 
-def _get_all(obj: Union[DataArray, Dataset], key: Union[str, List[str]]) -> List[str]:
-    all_mappers = (_get_axis_coord, _get_measure, _get_with_standard_name, _get_measure)
+def _get_all(obj: Union[DataArray, Dataset], key: str) -> List[str]:
+    all_mappers = (_get_axis_coord, _get_measure, _get_with_standard_name)
     results = apply_mapper(all_mappers, obj, key, error=False, default=None)
     return results
 
 
-def _get_dims(obj: Union[DataArray, Dataset], key: Union[str, List[str]]):
+def _get_dims(obj: Union[DataArray, Dataset], key: str):
     return [k for k in _get_all(obj, key) if k in obj.dims]
 
 
-def _get_indexes(obj: Union[DataArray, Dataset], key: Union[str, List[str]]):
+def _get_indexes(obj: Union[DataArray, Dataset], key: str):
     return [k for k in _get_all(obj, key) if k in obj.indexes]
 
 
-def _get_coords(obj: Union[DataArray, Dataset], key: Union[str, List[str]]):
+def _get_coords(obj: Union[DataArray, Dataset], key: str):
     return [k for k in _get_all(obj, key) if k in obj.coords]
 
 
 #: Default mappers for common keys.
 _DEFAULT_KEY_MAPPERS: Mapping[str, Tuple[Mapper, ...]] = {
-    "dim": (_get_dims,),  # (_get_axis_coord, _get_with_standard_name),
-    "dims": (_get_dims,),  # (_get_axis_coord, _get_with_standard_name),  # transpose
+    "dim": (_get_dims,),
+    "dims": (_get_dims,),  # transpose
     "drop_dims": (_get_dims,),  # drop_dims
     "dimensions": (_get_dims,),  # stack
     "dims_dict": (_get_dims,),  # swap_dims, rename_dims

--- a/cf_xarray/accessor.py
+++ b/cf_xarray/accessor.py
@@ -360,7 +360,7 @@ def _get_with_standard_name(
 def _get_all(obj: Union[DataArray, Dataset], key: str) -> List[str]:
     """
     One or more of ('X', 'Y', 'Z', 'T', 'longitude', 'latitude', 'vertical', 'time',
-    'area', 'volume'), or arbitraty measures, or standard names
+    'area', 'volume'), or arbitrary measures, or standard names
     """
     all_mappers = (_get_axis_coord, _get_measure, _get_with_standard_name)
     results = apply_mapper(all_mappers, obj, key, error=False, default=None)
@@ -370,7 +370,7 @@ def _get_all(obj: Union[DataArray, Dataset], key: str) -> List[str]:
 def _get_dims(obj: Union[DataArray, Dataset], key: str) -> List[str]:
     """
     One or more of ('X', 'Y', 'Z', 'T', 'longitude', 'latitude', 'vertical', 'time',
-    'area', 'volume'), or arbitraty measures, or standard names present in .dims
+    'area', 'volume'), or arbitrary measures, or standard names present in .dims
     """
     return [k for k in _get_all(obj, key) if k in obj.dims]
 
@@ -378,7 +378,7 @@ def _get_dims(obj: Union[DataArray, Dataset], key: str) -> List[str]:
 def _get_indexes(obj: Union[DataArray, Dataset], key: str) -> List[str]:
     """
     One or more of ('X', 'Y', 'Z', 'T', 'longitude', 'latitude', 'vertical', 'time',
-    'area', 'volume'), or arbitraty measures, or standard names present in .indexes
+    'area', 'volume'), or arbitrary measures, or standard names present in .indexes
     """
     return [k for k in _get_all(obj, key) if k in obj.indexes]
 
@@ -386,7 +386,7 @@ def _get_indexes(obj: Union[DataArray, Dataset], key: str) -> List[str]:
 def _get_coords(obj: Union[DataArray, Dataset], key: str) -> List[str]:
     """
     One or more of ('X', 'Y', 'Z', 'T', 'longitude', 'latitude', 'vertical', 'time',
-    'area', 'volume'), or arbitraty measures, or standard names present in .coords
+    'area', 'volume'), or arbitrary measures, or standard names present in .coords
     """
     return [k for k in _get_all(obj, key) if k in obj.coords]
 

--- a/cf_xarray/accessor.py
+++ b/cf_xarray/accessor.py
@@ -249,7 +249,9 @@ def _get_groupby_time_accessor(var: Union[DataArray, Dataset], key: str) -> List
         return []
 
 
-def _get_axis_coord(var: Union[DataArray, Dataset], key: str) -> List[str]:
+def _get_axis_coord(
+    var: Union[DataArray, Dataset], key: str, error: bool = True
+) -> List[str]:
     """
     Translate from axis or coord name to variable name
 
@@ -283,7 +285,7 @@ def _get_axis_coord(var: Union[DataArray, Dataset], key: str) -> List[str]:
     """
 
     valid_keys = _COORD_NAMES + _AXIS_NAMES
-    if key not in valid_keys:
+    if error and key not in valid_keys:
         raise KeyError(
             f"cf_xarray did not understand key {key!r}. Expected one of {valid_keys!r}"
         )
@@ -311,6 +313,56 @@ def _get_axis_coord(var: Union[DataArray, Dataset], key: str) -> List[str]:
                     results.update((coord,))
 
     return list(results)
+
+
+def _get_all(var: Union[DataArray, Dataset], key: str) -> List[str]:
+
+    results = set(_get_axis_coord(var, key, error=False))
+    for func in (_get_measure, _get_with_standard_name):
+        results.update(func(var, key))
+
+    return list(results)
+
+
+def _get_dims(var: Union[DataArray, Dataset], key: str) -> List[str]:
+    results = set(_get_all(var, key)).intersection(var.dims)
+    return list(results)
+
+
+def _get_single_dim(var: Union[DataArray, Dataset], key: str) -> List[str]:
+    return _get_single(var, key, _get_dims)
+
+
+def _get_coords(var: Union[DataArray, Dataset], key: str) -> List[str]:
+    results = set(_get_all(var, key)).intersection(var.coords)
+    return list(results)
+
+
+def _get_single_coord(var: Union[DataArray, Dataset], key: str) -> List[str]:
+    return _get_single(var, key, _get_coords)
+
+
+def _get_indexes(var: Union[DataArray, Dataset], key: str) -> List[str]:
+    results = set(_get_all(var, key)).intersection(var.indexes)
+    return list(results)
+
+
+def _get_single_index(var: Union[DataArray, Dataset], key: str) -> List[str]:
+    return _get_single(var, key, _get_indexes)
+
+
+def _get_single(var: Union[DataArray, Dataset], key: str, func):
+
+    results = func(var, key)
+
+    if len(results) > 1:
+        raise KeyError(
+            f"Multiple results for {key!r} found: {results!r}. I expected only one."
+        )
+    elif len(results) == 0:
+        raise KeyError(f"No results found for {key!r}.")
+
+    return results
 
 
 def _get_measure_variable(
@@ -374,34 +426,30 @@ def _get_with_standard_name(
 
 #: Default mappers for common keys.
 _DEFAULT_KEY_MAPPERS: Mapping[str, Tuple[Mapper, ...]] = {
-    "dim": (_get_axis_coord, _get_with_standard_name),
-    "dims": (_get_axis_coord, _get_with_standard_name),  # transpose
-    "drop_dims": (_get_axis_coord, _get_with_standard_name),  # drop_dims
-    "dimensions": (_get_axis_coord, _get_with_standard_name),  # stack
-    "dims_dict": (_get_axis_coord, _get_with_standard_name),  # swap_dims, rename_dims
-    "shifts": (_get_axis_coord, _get_with_standard_name),  # shift, roll
-    "pad_width": (_get_axis_coord, _get_with_standard_name),  # shift, roll
-    "names": (
-        _get_axis_coord,
-        _get_measure,
-        _get_with_standard_name,
-    ),  # set_coords, reset_coords, drop_vars
-    "labels": (_get_axis_coord, _get_measure, _get_with_standard_name),  # drop
-    "coords": (_get_axis_coord, _get_with_standard_name),  # interp
-    "indexers": (_get_axis_coord, _get_with_standard_name),  # sel, isel, reindex
+    "dim": (_get_dims,),
+    "dims": (_get_dims,),  # transpose
+    "drop_dims": (_get_dims,),  # drop_dims
+    "dimensions": (_get_dims,),  # stack
+    "dims_dict": (_get_dims,),  # swap_dims, rename_dims
+    "shifts": (_get_dims,),  # shift, roll
+    "pad_width": (_get_dims,),  # shift, roll
+    "names": (_get_all,),  # set_coords, reset_coords, drop_vars
+    "labels": (_get_all,),  # drop
+    "coords": (_get_coords,),  # interp
+    "indexers": (_get_indexes,),  # sel, isel, reindex
     # "indexes": (_get_axis_coord,),  # set_index
-    "dims_or_levels": (_get_axis_coord, _get_with_standard_name),  # reset_index
-    "window": (_get_axis_coord, _get_with_standard_name),  # rolling_exp
-    "coord": (_get_axis_coord_single,),  # differentiate, integrate
+    "dims_or_levels": (_get_indexes,),  # reset_index
+    "window": (_get_dims,),  # rolling_exp
+    "coord": (_get_coords,),  # differentiate, integrate
     "group": (
         _get_axis_coord_single,
         _get_groupby_time_accessor,
         _get_with_standard_name,
     ),
-    "indexer": (_get_axis_coord_single,),  # resample
-    "variables": (_get_axis_coord, _get_with_standard_name),  # sortby
+    "indexer": (_get_single_index,),  # resample
+    "variables": (_get_all,),  # sortby
     "weights": (_get_measure_variable,),  # type: ignore
-    "chunks": (_get_axis_coord, _get_with_standard_name),  # chunk
+    "chunks": (_get_dims,),  # chunk
 }
 
 
@@ -907,7 +955,7 @@ class CFAccessor:
         # these are valid for .sel, .isel, .coarsen
         all_mappers = ChainMap(
             key_mappers,
-            dict.fromkeys(var_kws, (_get_axis_coord, _get_with_standard_name)),
+            dict.fromkeys(var_kws, (_get_all,)),
         )
 
         for key in set(all_mappers) & set(kwargs):

--- a/cf_xarray/accessor.py
+++ b/cf_xarray/accessor.py
@@ -17,7 +17,7 @@ from typing import (
     Tuple,
     TypeVar,
     Union,
-    cast
+    cast,
 )
 
 import xarray as xr
@@ -416,7 +416,11 @@ def _single(func: F) -> F:
             raise KeyError(f"No results found for {key!r}.")
         return results
 
-    wrapper.__doc__ = func.__doc__.replace("One or more of", "One of") if func.__doc__ else func.__doc__
+    wrapper.__doc__ = (
+        func.__doc__.replace("One or more of", "One of")
+        if func.__doc__
+        else func.__doc__
+    )
 
     return cast(F, wrapper)
 

--- a/cf_xarray/accessor.py
+++ b/cf_xarray/accessor.py
@@ -382,31 +382,25 @@ _get_all.__doc__ = (
 )
 
 
-def _dims(func):
-    @functools.wraps(func)
-    def get_dims(obj: Union[DataArray, Dataset], key: str):
-        return [k for k in func(obj, key) if k in obj.dims]
-
-    get_dims.__doc__ = func.__doc__ + " present in .dims"
-    return get_dims
+def _get_dims(obj: Union[DataArray, Dataset], key: str):
+    return [k for k in _get_all(obj, key) if k in obj.dims]
 
 
-def _indexes(func):
-    @functools.wraps(func)
-    def get_indexes(obj: Union[DataArray, Dataset], key: str):
-        return [k for k in func(obj, key) if k in obj.dims]
-
-    get_indexes.__doc__ = func.__doc__ + " present in .indexes"
-    return get_indexes
+_get_dims.__doc__ = _get_all.__doc__ + " present in .dims"
 
 
-def _coords(func):
-    @functools.wraps(func)
-    def get_coords(obj: Union[DataArray, Dataset], key: str):
-        return [k for k in func(obj, key) if k in obj.coords]
+def _get_indexes(obj: Union[DataArray, Dataset], key: str):
+    return [k for k in _get_all(obj, key) if k in obj.indexes]
 
-    get_coords.__doc__ = func.__doc__ + " present in .coords"
-    return get_coords
+
+_get_indexes.__doc__ = _get_all.__doc__ + " present in .indexes"
+
+
+def _get_coords(obj: Union[DataArray, Dataset], key: str):
+    return [k for k in _get_all(obj, key) if k in obj.coords]
+
+
+_get_coords.__doc__ = _get_all.__doc__ + " present in .coords"
 
 
 def _variables(func):
@@ -436,26 +430,26 @@ def _single(func):
 
 #: Default mappers for common keys.
 _DEFAULT_KEY_MAPPERS: Mapping[str, Tuple[Mapper, ...]] = {
-    "dim": (_dims(_get_all),),
-    "dims": (_dims(_get_all),),  # transpose
-    "drop_dims": (_dims(_get_all),),  # drop_dims
-    "dimensions": (_dims(_get_all),),  # stack
-    "dims_dict": (_dims(_get_all),),  # swap_dims, rename_dims
-    "shifts": (_dims(_get_all),),  # shift, roll
-    "pad_width": (_dims(_get_all),),  # shift, roll
+    "dim": (_get_dims,),
+    "dims": (_get_dims,),  # transpose
+    "drop_dims": (_get_dims,),  # drop_dims
+    "dimensions": (_get_dims,),  # stack
+    "dims_dict": (_get_dims,),  # swap_dims, rename_dims
+    "shifts": (_get_dims,),  # shift, roll
+    "pad_width": (_get_dims,),  # shift, roll
     "names": (_get_all,),  # set_coords, reset_coords, drop_vars
-    "labels": (_indexes(_get_all),),  # drop_sel
-    "coords": (_dims(_get_all),),  # interp
-    "indexers": (_dims(_get_all),),  # sel, isel, reindex
+    "labels": (_get_indexes,),  # drop_sel
+    "coords": (_get_dims,),  # interp
+    "indexers": (_get_dims,),  # sel, isel, reindex
     # "indexes": (_get_axis_coord,),  # set_index
-    "dims_or_levels": (_dims(_get_all),),  # reset_index
-    "window": (_dims(_get_all),),  # rolling_exp
-    "coord": (_single(_coords(_get_all)),),  # differentiate, integrate
+    "dims_or_levels": (_get_dims,),  # reset_index
+    "window": (_get_dims,),  # rolling_exp
+    "coord": (_single(_get_coords),),  # differentiate, integrate
     "group": (_single(_get_all), _get_groupby_time_accessor),  # groupby
-    "indexer": (_single(_indexes(_get_all)),),  # resample
+    "indexer": (_single(_get_indexes),),  # resample
     "variables": (_get_all,),  # sortby
     "weights": (_variables(_single(_get_all)),),  # type: ignore
-    "chunks": (_dims(_get_all),),  # chunk
+    "chunks": (_get_dims,),  # chunk
 }
 
 

--- a/cf_xarray/accessor.py
+++ b/cf_xarray/accessor.py
@@ -346,6 +346,9 @@ def _get_with_standard_name(
     obj: Union[DataArray, Dataset], name: Union[str, List[str]]
 ) -> List[str]:
     """ returns a list of variable names with standard name == name. """
+    if name is None:
+        return []
+
     varnames = []
     if isinstance(obj, DataArray):
         obj = obj._to_temp_dataset()
@@ -769,9 +772,9 @@ class _CFWrappedPlotMethods:
     def _plot_decorator(self, func):
         """
         This decorator is used to set default kwargs on plotting functions.
-
-        For now, this is setting ``xincrease`` and ``yincrease``. It could set
-        other arguments in the future.
+        For now, this can
+        1. set ``xincrease`` and ``yincrease``.
+        2. automatically set ``x`` or ``y``.
         """
         valid_keys = self.accessor.keys()
 
@@ -795,7 +798,8 @@ class _CFWrappedPlotMethods:
                 return kwargs
 
             is_line_plot = (func.__name__ == "line") or (
-                func.__name__ == "wrapper" and kwargs.get("hue")
+                func.__name__ == "wrapper"
+                and (kwargs.get("hue") or self._obj.ndim == 1)
             )
             if is_line_plot:
                 if not kwargs.get("hue"):
@@ -818,7 +822,7 @@ class _CFWrappedPlotMethods:
             obj=self._obj,
             attr="plot",
             accessor=self.accessor,
-            key_mappers=dict.fromkeys(self._keys, (_single(_get_coords),)),
+            key_mappers=dict.fromkeys(self._keys, (_single(_get_all),)),
         )
         return self._plot_decorator(plot)(*args, **kwargs)
 

--- a/cf_xarray/accessor.py
+++ b/cf_xarray/accessor.py
@@ -478,7 +478,7 @@ def _build_docstring(func):
     for k in set(sig.parameters.keys()) & set(_DEFAULT_KEY_MAPPERS):
         mappers = _DEFAULT_KEY_MAPPERS.get(k, [])
         docstring = ";\n\t\t\t".join(
-            mapper_docstrings.get(id(mapper), "unknown. please open an issue.")
+            mapper_docstrings.get(mapper, "unknown. please open an issue.")
             for mapper in mappers
         )
         string += f"\t\t{k}: {docstring} \n"

--- a/cf_xarray/datasets.py
+++ b/cf_xarray/datasets.py
@@ -70,7 +70,6 @@ anc["q_error_limit"] = (
 anc["q_detection_limit"] = xr.DataArray(
     1e-3, attrs=dict(standard_name="specific_humidity detection_minimum", units="g/g")
 )
-anc
 
 
 multiple = xr.Dataset()

--- a/cf_xarray/datasets.py
+++ b/cf_xarray/datasets.py
@@ -70,6 +70,7 @@ anc["q_error_limit"] = (
 anc["q_detection_limit"] = xr.DataArray(
     1e-3, attrs=dict(standard_name="specific_humidity detection_minimum", units="g/g")
 )
+anc
 
 
 multiple = xr.Dataset()
@@ -121,7 +122,7 @@ romsds["zeta"] = ("ocean_time", [-0.155356, -0.127435])
 romsds["temp"] = (
     ("ocean_time", "s_rho"),
     [np.linspace(20, 30, 30)] * 2,
-    {"coordinates": "z_rho_dummy"},
+    {"coordinates": "z_rho_dummy", "standard_name": "sea_water_potential_temperature"},
 )
 romsds["temp"].encoding["coordinates"] = "s_rho"
 romsds.coords["z_rho_dummy"] = (

--- a/cf_xarray/tests/test_accessor.py
+++ b/cf_xarray/tests/test_accessor.py
@@ -638,7 +638,7 @@ def test_docstring():
         + cf_xarray.accessor._COORD_NAMES
         + cf_xarray.accessor._CELL_MEASURES
     )
-    expected = f"One or more of {all_keys!r}, or arbitraty measures, or standard names"
+    expected = f"One or more of {all_keys!r}, or arbitrary measures, or standard names"
     assert get_all_doc.split() == expected.split()
     for name in ["dims", "indexes", "coords"]:
         actual = getattr(cf_xarray.accessor, f"_get_{name}").__doc__

--- a/cf_xarray/tests/test_accessor.py
+++ b/cf_xarray/tests/test_accessor.py
@@ -624,9 +624,26 @@ def test_get_bounds_dim_name():
 
 
 def test_docstring():
-    print(airds.cf.groupby.__doc__)
     assert "One of ('X'" in airds.cf.groupby.__doc__
+    assert "Time variable accessor e.g. 'T.month'" in airds.cf.groupby.__doc__
     assert "One or more of ('X'" in airds.cf.mean.__doc__
+    assert "present in .dims" in airds.cf.drop_dims.__doc__
+    assert "present in .coords" in airds.cf.integrate.__doc__
+    assert "present in .indexes" in airds.cf.resample.__doc__
+
+    # Make sure docs are up to date
+    get_all_doc = cf_xarray.accessor._get_all.__doc__
+    all_keys = (
+        cf_xarray.accessor._AXIS_NAMES
+        + cf_xarray.accessor._COORD_NAMES
+        + cf_xarray.accessor._CELL_MEASURES
+    )
+    expected = f"One or more of {all_keys!r}, or arbitraty measures, or standard names"
+    assert get_all_doc.split() == expected.split()
+    for name in ["dims", "indexes", "coords"]:
+        actual = getattr(cf_xarray.accessor, f"_get_{name}").__doc__
+        expected = get_all_doc + f" present in .{name}"
+        assert actual.split() == expected.split()
 
 
 def _make_names(prefixes):

--- a/cf_xarray/tests/test_accessor.py
+++ b/cf_xarray/tests/test_accessor.py
@@ -932,7 +932,6 @@ def test_drop_sel_and_reset_coords(obj):
 
 @pytest.mark.parametrize("ds", datasets)
 def test_drop_dims(ds):
-    # Testing _get_dims
 
     # Add data_var and coord to test _get_dims
     ds["lon_var"] = ds["lon"]
@@ -945,16 +944,15 @@ def test_drop_dims(ds):
 
 @pytest.mark.parametrize("ds", datasets)
 def test_differentiate(ds):
-    # Testing _single(_get_coords)
 
-    # Add data_var and coord to test _get_dims
+    # Add data_var and coord to test _get_coords
     ds["lon_var"] = ds["lon"]
     ds = ds.assign_coords(lon_coord=ds["lon"])
 
-    # Axis
+    # Coordinate
     assert_identical(ds.differentiate("lon"), ds.cf.differentiate("lon"))
 
-    # Multiple keys
+    # Multiple coords (test error raised by _single)
     with pytest.raises(KeyError, match=".*I expected only one."):
         assert_identical(ds.differentiate("lon"), ds.cf.differentiate("X"))
 

--- a/cf_xarray/tests/test_accessor.py
+++ b/cf_xarray/tests/test_accessor.py
@@ -624,6 +624,7 @@ def test_get_bounds_dim_name():
 
 
 def test_docstring():
+    print(airds.cf.groupby.__doc__)
     assert "One of ('X'" in airds.cf.groupby.__doc__
     assert "One or more of ('X'" in airds.cf.mean.__doc__
 

--- a/cf_xarray/tests/test_accessor.py
+++ b/cf_xarray/tests/test_accessor.py
@@ -849,8 +849,7 @@ def test_standard_name_mapper():
 
 
 @pytest.mark.parametrize("obj", objects)
-@pytest.mark.parametrize("attr", ["drop", "drop_vars", "set_coords"])
-@pytest.mark.filterwarnings("ignore:dropping .* using `drop` .* deprecated")
+@pytest.mark.parametrize("attr", ["drop_vars", "set_coords"])
 def test_drop_vars_and_set_coords(obj, attr):
 
     # DataArray object has no attribute set_coords

--- a/cf_xarray/tests/test_accessor.py
+++ b/cf_xarray/tests/test_accessor.py
@@ -413,6 +413,10 @@ def test_dataarray_plot():
     np.testing.assert_equal(rv[0].get_xdata(), obj.lat.data)
     plt.close()
 
+    rv = obj.isel(time=0, lon=1).cf.plot(x="lat")
+    np.testing.assert_equal(rv[0].get_xdata(), obj.lat.data)
+    plt.close()
+
     # various line plots and automatic guessing
     rv = obj.cf.isel(T=1, Y=[0, 1, 2]).cf.plot.line()
     np.testing.assert_equal(rv[0].get_xdata(), obj.lon.data)
@@ -864,6 +868,8 @@ def test_standard_name_mapper():
     actual = da.cf.sortby("standard_label")
     expected = da.sortby("label")
     assert_identical(actual, expected)
+
+    assert cf_xarray.accessor._get_with_standard_name(da, None) == []
 
 
 @pytest.mark.parametrize("obj", objects)

--- a/cf_xarray/tests/test_accessor.py
+++ b/cf_xarray/tests/test_accessor.py
@@ -932,10 +932,31 @@ def test_drop_sel_and_reset_coords(obj):
 
 @pytest.mark.parametrize("ds", datasets)
 def test_drop_dims(ds):
+    # Testing _get_dims
+
+    # Add data_var and coord to test _get_dims
+    ds["lon_var"] = ds["lon"]
+    ds = ds.assign_coords(lon_coord=ds["lon"])
 
     # Axis and coordinate
     for cf_name in ["X", "longitude"]:
         assert_identical(ds.drop_dims("lon"), ds.cf.drop_dims(cf_name))
+
+
+@pytest.mark.parametrize("ds", datasets)
+def test_differentiate(ds):
+    # Testing _single(_get_coords)
+
+    # Add data_var and coord to test _get_dims
+    ds["lon_var"] = ds["lon"]
+    ds = ds.assign_coords(lon_coord=ds["lon"])
+
+    # Axis
+    assert_identical(ds.differentiate("lon"), ds.cf.differentiate("lon"))
+
+    # Multiple keys
+    with pytest.raises(KeyError, match=".*I expected only one."):
+        assert_identical(ds.differentiate("lon"), ds.cf.differentiate("X"))
 
 
 def test_new_standard_name_mappers():

--- a/doc/examples/introduction.ipynb
+++ b/doc/examples/introduction.ipynb
@@ -982,7 +982,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.8"
+   "version": "3.9.1"
   },
   "toc": {
    "base_numbering": 1,

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -9,7 +9,7 @@ v0.4.1 (unreleased)
 - Replace ``cf.describe()`` with :py:meth:`Dataset.cf.__repr__`. By `Mattia Almansi`_.
 - Automatically set ``x`` or ``y`` for :py:attr:`DataArray.cf.plot`. By `Deepak Cherian`_.
 - Added scripts to document :ref:`criteria` with tables. By `Mattia Almansi`_.
-- Support for ``.drop()``, ``.drop_vars()``, ``.drop_sel()``, ``.drop_dims()``, ``.set_coords()``, ``.reset_coords()``. By `Mattia Almansi`_.
+- Support for ``.drop_vars()``, ``.drop_sel()``, ``.drop_dims()``, ``.set_coords()``, ``.reset_coords()``. By `Mattia Almansi`_.
 - Support for using ``standard_name`` in more functions. (:pr:`128`) By `Deepak Cherian`_
 - Allow :py:meth:`DataArray.cf.__getitem__` with standard names. By `Deepak Cherian`_
 - Rewrite the ``values`` of :py:attr:`Dataset.coords` and :py:attr:`Dataset.data_vars` with objects returned


### PR DESCRIPTION
- [x] closes #175, closes #107 
- [x] Add more tests
- [x] Copy over #165 tests
- [ ] Explicitly add conflicting functions

@dcherian were you thinking something along these lines?

Currently `_get_dims/coords/indexes` use `_get_axis_coord` and `_get_with_standard_name`.
We can probably get rid of `_get_axis_coord` and `_get_with_standard_name`, I just wanted to check first whether that's the way to go as they are used in many places. Not sure if all `_get_axis_coord` can be replaced by the same function (e.g., `_get_coords`) or it's not that simple.

All tests are passing, I didn't add new tests yet.
