### PR TITLE
Do not return <this-array> instances

### DIFF
--- a/cf_xarray/accessor.py
+++ b/cf_xarray/accessor.py
@@ -351,10 +351,10 @@ def _get_with_standard_name(
 
     varnames = []
     if isinstance(obj, DataArray):
-        obj = obj._to_temp_dataset()
+        obj = obj.coords.to_dataset()
     for vname, var in obj.variables.items():
         stdname = var.attrs.get("standard_name", None)
-        if stdname == name and vname != xr.core.dataarray._THIS_ARRAY:
+        if stdname == name:
             varnames.append(str(vname))
 
     return varnames

--- a/cf_xarray/accessor.py
+++ b/cf_xarray/accessor.py
@@ -354,7 +354,7 @@ def _get_with_standard_name(
         obj = obj._to_temp_dataset()
     for vname, var in obj.variables.items():
         stdname = var.attrs.get("standard_name", None)
-        if stdname == name:
+        if stdname == name and vname != xr.core.dataarray._THIS_ARRAY:
             varnames.append(str(vname))
 
     return varnames

--- a/cf_xarray/tests/test_accessor.py
+++ b/cf_xarray/tests/test_accessor.py
@@ -185,6 +185,10 @@ def test_getitem_standard_name():
     expected = airds["air"]
     assert_identical(actual, expected)
 
+    actual = airds.lat.cf["latitude"]
+    expected = airds["lat"]
+    assert_identical(actual, expected)
+
     ds = airds.copy(deep=True)
     ds["air2"] = ds.air
     with pytest.raises(KeyError):


### PR DESCRIPTION
Small fix for #179.

Modified `_get_with_standard_name` so that when used on a `DataArray`, it cannot return itself (the `<this-array>` variable in the temp dataset). This match the previous behavior (I think?) and fits the returned error message : `ds.air.cf['air_temperature']` fails because 'air_temperature' doesn't appear in `ds.air.cf`.  But `ds.lat.cf['latitude']` works, since 'latitude' appears in `ds.lat.cf`.

Also added a minimal test.