### PR TITLE
Add unit support to cf-xarray

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,6 +48,29 @@ jobs:
           name: codecov-umbrella
           fail_ci_if_error: false
 
+  no-optional-deps:
+    name: no-optional-deps
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          channels: conda-forge
+          mamba-version: "*"
+          activate-environment: cf_xarray_test
+          auto-update-conda: false
+          python-version: ${{ matrix.python-version }}
+      - name: Set up conda environment
+        shell: bash -l {0}
+        run: |
+          mamba env update -f ci/environment-no-optional-deps.yml
+          python -m pip install -e .
+          conda list
+      - name: Run Tests
+        shell: bash -l {0}
+        run: |
+          pytest -n 2
+
   upstream-dev:
     name: upstream-dev
     runs-on: ubuntu-latest

--- a/cf_xarray/tests/test_units.py
+++ b/cf_xarray/tests/test_units.py
@@ -4,7 +4,11 @@ Reused with modification from MetPy under the terms of the BSD 3-Clause License.
 Copyright (c) 2017 MetPy Developers.
 """
 
+import pytest
+
 from ..units import units
+
+pytest.importskip("pint")
 
 
 def test_added_degrees_units():

--- a/cf_xarray/tests/test_units.py
+++ b/cf_xarray/tests/test_units.py
@@ -49,6 +49,12 @@ def test_percent_units():
     assert str(units("%").units) == "percent"
 
 
+@pytest.mark.xfail(reason="not supported by pint, yet: hgrecco/pint#1295")
 def test_udunits_power_syntax():
     """Test that UDUNITS style powers are properly parsed and interpreted."""
     assert units("m2 s-2").units == units.m ** 2 / units.s ** 2
+
+
+def test_udunits_power_syntax_parse_units():
+    """Test that UDUNITS style powers are properly parsed and interpreted."""
+    assert units.parse_units("m2 s-2") == units.m ** 2 / units.s ** 2

--- a/cf_xarray/tests/test_units.py
+++ b/cf_xarray/tests/test_units.py
@@ -8,7 +8,7 @@ import pytest
 
 from ..units import units
 
-pytest.importskip("pint")
+pytest.importorskip("pint")
 
 
 def test_added_degrees_units():

--- a/cf_xarray/tests/test_units.py
+++ b/cf_xarray/tests/test_units.py
@@ -1,0 +1,50 @@
+r"""Tests the operation of cf_xarray's ported unit support code.
+
+Reused with modification from MetPy under the terms of the BSD 3-Clause License.
+Copyright (c) 2017 MetPy Developers.
+"""
+
+from ..units import units
+
+
+def test_added_degrees_units():
+    """Test that our added degrees units are present in the registry."""
+    # Test equivalence of abbreviations/aliases to our defined names
+    assert str(units("degrees_N").units) == "degrees_north"
+    assert str(units("degreesN").units) == "degrees_north"
+    assert str(units("degree_north").units) == "degrees_north"
+    assert str(units("degree_N").units) == "degrees_north"
+    assert str(units("degreeN").units) == "degrees_north"
+    assert str(units("degrees_E").units) == "degrees_east"
+    assert str(units("degreesE").units) == "degrees_east"
+    assert str(units("degree_east").units) == "degrees_east"
+    assert str(units("degree_E").units) == "degrees_east"
+    assert str(units("degreeE").units) == "degrees_east"
+
+    # Test equivalence of our defined units to base units
+    assert units("degrees_north") == units("degrees")
+    assert units("degrees_north").to_base_units().units == units.radian
+    assert units("degrees_east") == units("degrees")
+    assert units("degrees_east").to_base_units().units == units.radian
+
+
+def test_gpm_unit():
+    """Test that the gpm unit does alias to meters."""
+    x = 1 * units("gpm")
+    assert str(x.units) == "meter"
+
+
+def test_psu_unit():
+    """Test that the psu unit are present in the registry."""
+    x = 1 * units("psu")
+    assert str(x.units) == "practical_salinity_units"
+
+
+def test_percent_units():
+    """Test that percent sign units are properly parsed and interpreted."""
+    assert str(units("%").units) == "percent"
+
+
+def test_udunits_power_syntax():
+    """Test that UDUNITS style powers are properly parsed and interpreted."""
+    assert units("m2 s-2").units == units.m ** 2 / units.s ** 2

--- a/cf_xarray/tests/test_units.py
+++ b/cf_xarray/tests/test_units.py
@@ -41,7 +41,7 @@ def test_gpm_unit():
 def test_psu_unit():
     """Test that the psu unit are present in the registry."""
     x = 1 * units("psu")
-    assert str(x.units) == "practical_salinity_units"
+    assert str(x.units) == "practical_salinity_unit"
 
 
 def test_percent_units():

--- a/cf_xarray/tests/test_units.py
+++ b/cf_xarray/tests/test_units.py
@@ -6,9 +6,9 @@ Copyright (c) 2017 MetPy Developers.
 
 import pytest
 
-from ..units import units
-
 pytest.importorskip("pint")
+
+from ..units import units
 
 
 def test_added_degrees_units():

--- a/cf_xarray/units.py
+++ b/cf_xarray/units.py
@@ -10,7 +10,6 @@ import warnings
 import pint
 from pint import DimensionalityError, UndefinedUnitError, UnitStrippedWarning
 
-
 # Create registry, with preprocessors for UDUNITS-style powers (m2 s-2) and percent signs
 units = pint.UnitRegistry(
     autoconvert_offset_to_baseunit=True,
@@ -22,7 +21,7 @@ units = pint.UnitRegistry(
         ),
         lambda string: string.replace("%", "percent"),
     ],
-    force_ndarray_like=True
+    force_ndarray_like=True,
 )
 
 units.define(

--- a/cf_xarray/units.py
+++ b/cf_xarray/units.py
@@ -1,0 +1,44 @@
+r"""Module to provide unit support via pint approximating UDUNITS/CF.
+
+Reused with modification from MetPy under the terms of the BSD 3-Clause License.
+Copyright (c) 2015,2017,2019 MetPy Developers.
+"""
+import re
+
+import pint
+
+UndefinedUnitError = pint.UndefinedUnitError
+DimensionalityError = pint.DimensionalityError
+UnitStrippedWarning = pint.UnitStrippedWarning
+
+# Create registry, with preprocessors for UDUNITS-style powers (m2 s-2) and percent signs
+units = pint.UnitRegistry(
+    autoconvert_offset_to_baseunit=True,
+    preprocessors=[
+        functools.partial(
+            re.sub,
+            r"(?<=[A-Za-z])(?![A-Za-z])(?<![0-9\-][eE])(?<![0-9\-])(?=[0-9\-])",
+            "**",
+        ),
+        lambda string: string.replace("%", "percent"),
+    ],
+)
+
+units.define(
+    pint.unit.UnitDefinition("percent", "%", (), pint.converters.ScaleConverter(0.01))
+)
+
+# Define commonly encoutered units (both CF and non-CF) not defined by pint
+units.define(
+    "degrees_north = degree = degrees_N = degreesN = degree_north = degree_N = degreeN"
+)
+units.define(
+    "degrees_east = degree = degrees_E = degreesE = degree_east = degree_E = degreeE"
+)
+units.define("@alias meter = gpm")
+units.define("practical_salinity_units = [] = psu")
+
+# Enable pint's built-in matplotlib support
+units.setup_matplotlib()
+
+del pint

--- a/cf_xarray/units.py
+++ b/cf_xarray/units.py
@@ -8,7 +8,11 @@ import re
 import warnings
 
 import pint
-from pint import DimensionalityError, UndefinedUnitError, UnitStrippedWarning
+from pint import (  # noqa: F401
+    DimensionalityError,
+    UndefinedUnitError,
+    UnitStrippedWarning,
+)
 
 # Create registry, with preprocessors for UDUNITS-style powers (m2 s-2) and percent signs
 units = pint.UnitRegistry(

--- a/cf_xarray/units.py
+++ b/cf_xarray/units.py
@@ -15,7 +15,9 @@ units = pint.UnitRegistry(
     autoconvert_offset_to_baseunit=True,
     preprocessors=[
         functools.partial(
-            re.compile(r"(?<=[A-Za-z])(?![A-Za-z])(?<![0-9\-][eE])(?<![0-9\-])(?=[0-9\-])").sub,
+            re.compile(
+                r"(?<=[A-Za-z])(?![A-Za-z])(?<![0-9\-][eE])(?<![0-9\-])(?=[0-9\-])"
+            ).sub,
             "**",
         ),
         lambda string: string.replace("%", "percent"),

--- a/cf_xarray/units.py
+++ b/cf_xarray/units.py
@@ -15,8 +15,7 @@ units = pint.UnitRegistry(
     autoconvert_offset_to_baseunit=True,
     preprocessors=[
         functools.partial(
-            re.sub,
-            r"(?<=[A-Za-z])(?![A-Za-z])(?<![0-9\-][eE])(?<![0-9\-])(?=[0-9\-])",
+            re.compile(r"(?<=[A-Za-z])(?![A-Za-z])(?<![0-9\-][eE])(?<![0-9\-])(?=[0-9\-])").sub,
             "**",
         ),
         lambda string: string.replace("%", "percent"),

--- a/cf_xarray/units.py
+++ b/cf_xarray/units.py
@@ -5,12 +5,11 @@ Copyright (c) 2015,2017,2019 MetPy Developers.
 """
 import functools
 import re
+import warnings
 
 import pint
+from pint import DimensionalityError, UndefinedUnitError, UnitStrippedWarning
 
-UndefinedUnitError = pint.UndefinedUnitError
-DimensionalityError = pint.DimensionalityError
-UnitStrippedWarning = pint.UnitStrippedWarning
 
 # Create registry, with preprocessors for UDUNITS-style powers (m2 s-2) and percent signs
 units = pint.UnitRegistry(
@@ -23,6 +22,7 @@ units = pint.UnitRegistry(
         ),
         lambda string: string.replace("%", "percent"),
     ],
+    force_ndarray_like=True
 )
 
 units.define(
@@ -37,9 +37,18 @@ units.define(
     "degrees_east = degree = degrees_E = degreesE = degree_east = degree_E = degreeE"
 )
 units.define("@alias meter = gpm")
-units.define("practical_salinity_units = [] = psu")
+units.define("practical_salinity_unit = [] = psu")
 
 # Enable pint's built-in matplotlib support
-units.setup_matplotlib()
+try:
+    units.setup_matplotlib()
+except ImportError:
+    warnings.warn(
+        "Import(s) unavailable to set up matplotlib support...skipping this portion "
+        "of the setup."
+    )
+
+# Set as application registry
+pint.set_application_registry(units)
 
 del pint

--- a/cf_xarray/units.py
+++ b/cf_xarray/units.py
@@ -3,6 +3,7 @@ r"""Module to provide unit support via pint approximating UDUNITS/CF.
 Reused with modification from MetPy under the terms of the BSD 3-Clause License.
 Copyright (c) 2015,2017,2019 MetPy Developers.
 """
+import functools
 import re
 
 import pint

--- a/ci/environment-no-optional-deps.yml
+++ b/ci/environment-no-optional-deps.yml
@@ -1,0 +1,13 @@
+name: cf_xarray_test
+channels:
+  - conda-forge
+dependencies:
+  - pytest-cov
+  - pytest
+  - pytest-xdist
+  - dask
+  - matplotlib-base
+  - netcdf4
+  - pandas
+  - pooch
+  - xarray

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -9,5 +9,6 @@ dependencies:
   - matplotlib-base
   - netcdf4
   - pandas
+  - pint
   - pooch
   - xarray

--- a/ci/upstream-dev-env.yml
+++ b/ci/upstream-dev-env.yml
@@ -12,3 +12,4 @@ dependencies:
   - pooch
   - pip:
     - git+https://github.com/pydata/xarray
+    - git+https://github.com/hgrecco/pint

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -6,6 +6,8 @@ What's New
 v0.5.2 (unreleased)
 ===================
 
+- Begin adding support for units with a unit registry for pint arrays. :pr:`197`.
+  By `Jon Thielen`_ and `Justus Magin`_.
 - Added :py:attr:`DataArray.cf.formula_terms` and :py:attr:`Dataset.cf.formula_terms`.
   By `Deepak Cherian`_.
 - Added :py:attr:`Dataset.cf.bounds` to return a dictionary mapping valid keys to the variable names of their bounds. By `Mattia Almansi`_.
@@ -100,6 +102,8 @@ v0.1.3
 - Support expanding key to multiple dimension names.
 
 .. _`Mattia Almansi`: https://github.com/malmans2
+.. _`Justus Magin`: https://github.com/keewis
+.. _`Jon Thielen`: https://github.com/jthielen
 .. _`Anderson Banihirwe`: https://github.com/andersy005
 .. _`Pascal Bourgault`: https://github.com/aulemahal
 .. _`Deepak Cherian`: https://github.com/dcherian

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,7 @@ skip_gitignore = true
 force_to_top = true
 default_section = THIRDPARTY
 known_first_party = cf_xarray
-known_third_party = dask,matplotlib,numpy,pandas,pytest,setuptools,sphinx_autosummary_accessors,xarray
+known_third_party = dask,matplotlib,numpy,pandas,pint,pytest,setuptools,sphinx_autosummary_accessors,xarray
 
 # Most of the numerical computing stack doesn't have type annotations yet.
 [mypy-affine.*]

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,7 @@ skip_gitignore = true
 force_to_top = true
 default_section = THIRDPARTY
 known_first_party = cf_xarray
-known_third_party = dask,matplotlib,numpy,pandas,pkg_resources,pint,pytest,setuptools,sphinx_autosummary_accessors,xarray
+known_third_party = dask,matplotlib,numpy,pandas,pint,pkg_resources,pytest,setuptools,sphinx_autosummary_accessors,xarray
 
 # Most of the numerical computing stack doesn't have type annotations yet.
 [mypy-affine.*]


### PR DESCRIPTION
Closes https://github.com/xarray-contrib/pint-xarray/issues/26

As discussed in https://github.com/xarray-contrib/pint-xarray/issues/26, this PR adds a copy of MetPy's Pint registry (which has some customization to better support CF/UDUNITS-style units most commonly found in CF-compliant NetCDF files) to cf-xarray. However, right now that is *all* that this does at this point, and so, I'd like to put this up now as a work-in-progress and hopefully start a more detailed conversation about how to move forward with this:

- **Main Question**: how should cf-xarray relate to pint-xarray?
  - inherit `.pint` accessor in the `.cf` accessor and use with this registry?
  - set this ported registry to the application registry and provide documentation on how to use it with `pint-xarray`? <-- my preference
  - just provide this ported registry as a standalone entity, but document how to incorporate it and `pint-xarray` into common CF-related workflows?
- Should Pint and this registry be a required or optional dependency?
- How should we handle matplotlib support (which requires enabling on the registry with `units.setup_matplotlib()`) and testing?
- How should this unit support best be documented and tested (in isolation from a calculation suite like MetPy has)?

However, feel free to bring up any other related discussion points as well!

cc @dcherian, @keewis