### PR TITLE
Add thickness as special measure name?

### DIFF
--- a/cf_xarray/accessor.py
+++ b/cf_xarray/accessor.py
@@ -42,7 +42,7 @@ _AXIS_NAMES = ("X", "Y", "Z", "T")
 _COORD_NAMES = ("longitude", "latitude", "vertical", "time")
 
 #:  Cell measures understood by cf_xarray.
-_CELL_MEASURES = ("area", "volume")
+_CELL_MEASURES = ("thickness", "area", "volume")
 
 # Define the criteria for coordinate matches
 # Copied from metpy
@@ -362,7 +362,7 @@ def _get_with_standard_name(
 def _get_all(obj: Union[DataArray, Dataset], key: str) -> List[str]:
     """
     One or more of ('X', 'Y', 'Z', 'T', 'longitude', 'latitude', 'vertical', 'time',
-    'area', 'volume'), or arbitrary measures, or standard names
+    'thickness', 'area', 'volume'), or arbitrary measures, or standard names
     """
     all_mappers = (_get_axis_coord, _get_measure, _get_with_standard_name)
     results = apply_mapper(all_mappers, obj, key, error=False, default=None)
@@ -372,7 +372,7 @@ def _get_all(obj: Union[DataArray, Dataset], key: str) -> List[str]:
 def _get_dims(obj: Union[DataArray, Dataset], key: str) -> List[str]:
     """
     One or more of ('X', 'Y', 'Z', 'T', 'longitude', 'latitude', 'vertical', 'time',
-    'area', 'volume'), or arbitrary measures, or standard names present in .dims
+    'thickness', 'area', 'volume'), or arbitrary measures, or standard names present in .dims
     """
     return [k for k in _get_all(obj, key) if k in obj.dims]
 
@@ -380,7 +380,7 @@ def _get_dims(obj: Union[DataArray, Dataset], key: str) -> List[str]:
 def _get_indexes(obj: Union[DataArray, Dataset], key: str) -> List[str]:
     """
     One or more of ('X', 'Y', 'Z', 'T', 'longitude', 'latitude', 'vertical', 'time',
-    'area', 'volume'), or arbitrary measures, or standard names present in .indexes
+    'thickness', 'area', 'volume'), or arbitrary measures, or standard names present in .indexes
     """
     return [k for k in _get_all(obj, key) if k in obj.indexes]
 
@@ -388,7 +388,7 @@ def _get_indexes(obj: Union[DataArray, Dataset], key: str) -> List[str]:
 def _get_coords(obj: Union[DataArray, Dataset], key: str) -> List[str]:
     """
     One or more of ('X', 'Y', 'Z', 'T', 'longitude', 'latitude', 'vertical', 'time',
-    'area', 'volume'), or arbitrary measures, or standard names present in .coords
+    'thickness', 'area', 'volume'), or arbitrary measures, or standard names present in .coords
     """
     return [k for k in _get_all(obj, key) if k in obj.coords]
 

--- a/cf_xarray/tests/test_accessor.py
+++ b/cf_xarray/tests/test_accessor.py
@@ -55,14 +55,14 @@ def test_repr():
                         vertical: n/a
 
     - Cell Measures:   area: ['cell_area']
-                       volume: n/a
+                       thickness, volume: n/a
 
     - Standard Names: * latitude: ['lat']
                       * longitude: ['lon']
                       * time: ['time']
 
     Data Variables:
-    - Cell Measures:   area, volume: n/a
+    - Cell Measures:   thickness, area, volume: n/a
 
     - Standard Names:   air_temperature: ['air']
     """
@@ -84,7 +84,7 @@ def test_repr():
                         vertical: n/a
 
     - Cell Measures:   area: ['cell_area']
-                       volume: n/a
+                       thickness, volume: n/a
 
     - Standard Names: * latitude: ['lat']
                       * longitude: ['lon']
@@ -104,12 +104,12 @@ def test_repr():
                         latitude: ['TLAT', 'ULAT']
                         vertical, time: n/a
 
-    - Cell Measures:   area, volume: n/a
+    - Cell Measures:   thickness, area, volume: n/a
 
     - Standard Names:   n/a
 
     Data Variables:
-    - Cell Measures:   area, volume: n/a
+    - Cell Measures:   thickness, area, volume: n/a
 
     - Standard Names:   sea_water_potential_temperature: ['TEMP']
                         sea_water_x_velocity: ['UVEL']
@@ -159,7 +159,7 @@ def test_cell_measures():
     Data Variables:
     - Cell Measures:   foo_measure: ['foo']
                        volume: ['foo']
-                       area: n/a
+                       thickness, area: n/a
 
     - Standard Names:   air_temperature: ['air']
                         foo_std_name: ['foo']


### PR DESCRIPTION
I wrote this looking at https://cmip6-preprocessing.readthedocs.io/en/latest/parsing_metrics.html. The thickness variable has `standard_name: cell_thickness` and is called `thkcello` in OMIP/CMIP/CMOR datasets. I *thought* datasets were setting the `cell_measures: "thickness: thkcello"` attribute but now I see that that is not true.

But since I had the code ready, here's the PR. I am not convinced we need to add this.

Also see #201 

cc @jbusecke