### PR TITLE
add bounds property

### DIFF
--- a/cf_xarray/accessor.py
+++ b/cf_xarray/accessor.py
@@ -1527,8 +1527,7 @@ class CFDatasetAccessor(CFAccessor):
         """
 
         obj = self._obj
-        keys = self.keys()
-        keys |= set(obj.variables if isinstance(obj, Dataset) else obj.coords)
+        keys = self.keys() | set(obj.variables)
 
         vardict = {
             key: apply_mapper(_get_bounds, obj, key, error=False) for key in keys

--- a/cf_xarray/accessor.py
+++ b/cf_xarray/accessor.py
@@ -257,7 +257,7 @@ def _get_measure(obj: Union[DataArray, Dataset], key: str) -> List[str]:
 
 def _get_bounds(obj: Union[DataArray, Dataset], key: str) -> List[str]:
     """
-    Translate from key (either CF key or variable name) to appropriate bounds names.
+    Translate from key (either CF key or variable name) to its bounds' variable names.
     This function interprets the ``bounds`` attribute on DataArrays.
 
     Parameters
@@ -269,15 +269,15 @@ def _get_bounds(obj: Union[DataArray, Dataset], key: str) -> List[str]:
 
     Returns
     -------
-    List[str], Variable name(s) in parent xarray object that matches axis or coordinate `key`
+    List[str], Variable name(s) in parent xarray object that are bounds of `key`
     """
 
-    results = []
+    results = set()
     for var in apply_mapper(_get_all, obj, key, error=False, default=[key]):
         if "bounds" in obj[var].attrs:
-            results += [obj[var].attrs["bounds"]]
+            results |= {obj[var].attrs["bounds"]}
 
-    return results
+    return list(results)
 
 
 def _get_with_standard_name(
@@ -1162,11 +1162,12 @@ class CFAccessor:
     @property
     def bounds(self) -> Dict[str, List[str]]:
         """
-        Property that returns a dictionary mapping valid keys to variable names of their bounds.
+        Property that returns a dictionary mapping valid keys
+        to the variable names of their bounds.
 
         Returns
         -------
-        Dictionary mapping valid keys to variable names of their bounds.
+        Dictionary mapping valid keys to the variable names of their bounds.
         """
 
         obj = self._obj
@@ -1191,7 +1192,7 @@ class CFAccessor:
     @property
     def standard_names(self) -> Dict[str, List[str]]:
         """
-        Returns a sorted list of standard names in Dataset.
+        Returns a dictionary mapping standard names to variable names.
 
         Parameters
         ----------
@@ -1200,7 +1201,7 @@ class CFAccessor:
 
         Returns
         -------
-        Dictionary of standard names in dataset
+        Dictionary mapping standard names to variable names.
         """
         if isinstance(self._obj, Dataset):
             variables = self._obj.variables

--- a/cf_xarray/tests/test_accessor.py
+++ b/cf_xarray/tests/test_accessor.py
@@ -61,10 +61,14 @@ def test_repr():
                       * longitude: ['lon']
                       * time: ['time']
 
+    - Bounds:   n/a
+
     Data Variables:
     - Cell Measures:   area, volume: n/a
 
     - Standard Names:   air_temperature: ['air']
+
+    - Bounds:   n/a
     """
     assert actual == dedent(expected)
 
@@ -89,6 +93,8 @@ def test_repr():
     - Standard Names: * latitude: ['lat']
                       * longitude: ['lon']
                       * time: ['time']
+
+    - Bounds:   n/a
     """
     assert actual == dedent(expected)
 
@@ -108,11 +114,15 @@ def test_repr():
 
     - Standard Names:   n/a
 
+    - Bounds:   n/a
+
     Data Variables:
     - Cell Measures:   area, volume: n/a
 
     - Standard Names:   sea_water_potential_temperature: ['TEMP']
                         sea_water_x_velocity: ['UVEL']
+
+    - Bounds:   n/a
     """
     assert actual == dedent(expected)
 
@@ -163,6 +173,8 @@ def test_cell_measures():
 
     - Standard Names:   air_temperature: ['air']
                         foo_std_name: ['foo']
+
+    - Bounds:   n/a
     """
     assert actual.endswith(dedent(expected))
 
@@ -625,6 +637,11 @@ def test_add_bounds(obj, dims):
 
 def test_bounds():
     ds = airds.copy(deep=True).cf.add_bounds("lat")
+
+    actual = ds.cf.bounds
+    expected = {"Y": ["lat_bounds"], "lat": ["lat_bounds"], "latitude": ["lat_bounds"]}
+    assert ds.cf.bounds == ds.cf["air"].cf.bounds == expected
+
     actual = ds.cf[["lat"]]
     expected = ds[["lat", "lat_bounds"]]
     assert_identical(actual, expected)
@@ -650,6 +667,19 @@ def test_bounds():
     assert len(record) == 0
     with pytest.warns(UserWarning, match="{'foo'} not found in object"):
         ds.cf[["air"]]
+
+    # Dataset has bounds
+    expected = """\
+    - Bounds:   Y: ['lat_bounds']
+                lat: ['lat_bounds']
+                latitude: ['lat_bounds']
+    """
+    assert dedent(expected) in ds.cf.__repr__()
+
+    # DataArray does not have bounds
+    expected = airds.cf["air"].cf.__repr__()
+    actual = ds.cf["air"].cf.__repr__()
+    assert actual == expected
 
 
 def test_bounds_to_vertices():

--- a/cf_xarray/tests/test_accessor.py
+++ b/cf_xarray/tests/test_accessor.py
@@ -640,7 +640,7 @@ def test_bounds():
 
     actual = ds.cf.bounds
     expected = {"Y": ["lat_bounds"], "lat": ["lat_bounds"], "latitude": ["lat_bounds"]}
-    assert ds.cf.bounds == ds.cf["air"].cf.bounds == expected
+    assert ds.cf.bounds == expected
 
     actual = ds.cf[["lat"]]
     expected = ds[["lat", "lat_bounds"]]

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -28,7 +28,6 @@ Attributes
    :template: autosummary/accessor_attribute.rst
 
     DataArray.cf.axes
-    DataArray.cf.bounds
     DataArray.cf.cell_measures
     DataArray.cf.coordinates
     DataArray.cf.standard_names

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -28,6 +28,7 @@ Attributes
    :template: autosummary/accessor_attribute.rst
 
     DataArray.cf.axes
+    DataArray.cf.bounds
     DataArray.cf.cell_measures
     DataArray.cf.coordinates
     DataArray.cf.standard_names
@@ -63,6 +64,7 @@ Attributes
    :template: autosummary/accessor_attribute.rst
 
     Dataset.cf.axes
+    Dataset.cf.bounds
     Dataset.cf.cell_measures
     Dataset.cf.coordinates
     Dataset.cf.standard_names

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -6,6 +6,7 @@ What's New
 v0.5.2 (unreleased)
 ===================
 
+- Added :py:attr:`Dataset.cf.axes` to return a dictionary mapping valid keys to the variable names of their bounds. By `Mattia Almansi`_.
 - :py:meth:`DataArray.cf.differentiate` and :py:meth:`Dataset.cf.differentiate` can optionally correct
   sign of the derivative by interpreting the ``"positive"`` attribute. By `Deepak Cherian`_.
 


### PR DESCRIPTION
Closes #210
Closes #215 

What should we do with DataArrays, where we can't have bounds because of the extra dimension?

Currently nothing specific is done. For example, when we extract a `DataArray` from a `Dataset`, `da.cf.bounds` is not empty, as we don't pop the `bounds` attribute from the coordinates. However, `da.cf.__repr__` shows `Bounds:  n/a` as the bounds variables are not present.

Should `cf.bounds` only include variables present in the object (and warn about missing bounds)?
Should `cf.bounds` be a property of `Datasets` only?
Should we pop the `bounds` attribute from coordinates when extracting a `DataArray`?
Should we only show `Bounds` in the representation of Datasets?

- [x] Tests
- [x] API docs
- [x] What's new
