### PR TITLE
Change coord criteria to {cf_name: criteria}

### DIFF
--- a/cf_xarray/accessor.py
+++ b/cf_xarray/accessor.py
@@ -221,8 +221,7 @@ def _get_axis_coord(var: Union[DataArray, Dataset], key: str) -> List[str]:
     results: Set = set()
     for coord in search_in:
         if key in coordinate_criteria:
-            for criterion in coordinate_criteria[key]:
-                expected = coordinate_criteria[key][criterion]
+            for criterion, expected in coordinate_criteria[key].items():
                 if (
                     coord in var.coords
                     and var.coords[coord].attrs.get(criterion, None) in expected

--- a/cf_xarray/accessor.py
+++ b/cf_xarray/accessor.py
@@ -220,15 +220,14 @@ def _get_axis_coord(var: Union[DataArray, Dataset], key: str) -> List[str]:
 
     results: Set = set()
     for coord in search_in:
-        for criterion, valid_values in coordinate_criteria.items():
-            if key in valid_values:
-                expected = valid_values[key]
+        if key in coordinate_criteria:
+            for criterion in coordinate_criteria[key]:
+                expected = coordinate_criteria[key][criterion]
                 if (
                     coord in var.coords
                     and var.coords[coord].attrs.get(criterion, None) in expected
                 ):
                     results.update((coord,))
-
     return list(results)
 
 

--- a/cf_xarray/criteria.py
+++ b/cf_xarray/criteria.py
@@ -10,23 +10,32 @@ import re
 from typing import MutableMapping, Tuple
 
 coordinate_criteria: MutableMapping[str, MutableMapping[str, Tuple]] = {
-    "standard_name": {
-        "X": ("projection_x_coordinate",),
-        "Y": ("projection_y_coordinate",),
-        "T": ("time",),
-        "time": ("time",),
-        "vertical": (
-            "air_pressure",
-            "height",
-            "depth",
-            "geopotential_height",
-            # computed dimensional coordinate name
-            "altitude",
-            "height_above_geopotential_datum",
-            "height_above_reference_ellipsoid",
-            "height_above_mean_sea_level",
+    "latitude": {
+        "standard_name": ("latitude",),
+		"units": (
+            "degree_north",
+            "degree_N",
+            "degreeN",
+            "degrees_north",
+            "degrees_N",
+            "degreesN",
         ),
-        "Z": (
+        "_CoordinateAxisType": ("Lat",)
+	},
+    "longitude": {
+        "standard_name": ("longitude",),
+		"units": (
+            "degree_east",
+            "degree_E",
+            "degreeE",
+            "degrees_east",
+            "degrees_E",
+            "degreesE",
+        ),
+        "_CoordinateAxisType": ("Lon",)
+	},
+    "Z": {
+        "standard_name": (
             "model_level_number",
             "atmosphere_ln_pressure_coordinate",
             "atmosphere_sigma_coordinate",
@@ -40,44 +49,49 @@ coordinate_criteria: MutableMapping[str, MutableMapping[str, Tuple]] = {
             "ocean_sigma_z_coordinate",
             "ocean_double_sigma_coordinate",
         ),
-        "latitude": ("latitude",),
-        "longitude": ("longitude",),
+        "_CoordinateAxisType": ("GeoZ", "Height", "Pressure",),
+        "axis": ("Z",)
     },
-    "_CoordinateAxisType": {
-        "T": ("Time",),
-        "Z": ("GeoZ", "Height", "Pressure"),
-        "Y": ("GeoY",),
-        "latitude": ("Lat",),
-        "X": ("GeoX",),
-        "longitude": ("Lon",),
-    },
-    "axis": {"T": ("T",), "Z": ("Z",), "Y": ("Y",), "X": ("X",)},
-    "cartesian_axis": {"T": ("T",), "Z": ("Z",), "Y": ("Y",), "X": ("X",)},
-    "positive": {"vertical": ("up", "down")},
-    "units": {
-        "latitude": (
-            "degree_north",
-            "degree_N",
-            "degreeN",
-            "degrees_north",
-            "degrees_N",
-            "degreesN",
+    "vertical": {
+        "standard_name":    (
+            "air_pressure",
+            "height",
+            "depth",
+            "geopotential_height",
+            # computed dimensional coordinate name
+            "altitude",
+            "height_above_geopotential_datum",
+            "height_above_reference_ellipsoid",
+            "height_above_mean_sea_level",
         ),
-        "longitude": (
-            "degree_east",
-            "degree_E",
-            "degreeE",
-            "degrees_east",
-            "degrees_E",
-            "degreesE",
-        ),
+        "positive": ("up", "down"),
     },
+    "X": {
+        "standard_name": ( "projection_x_coordinate",),
+        "_CoordinateAxisType": ("GeoX",),
+        "axis": ("X",)
+        },
+    "Y": {
+        "standard_name": ( "projection_y_coordinate",),
+        "_CoordinateAxisType": ("GeoY",),
+        "axis": ("Y",)
+        },
+    "T": {
+        "standard_name": ("time",),
+        "_CoordinateAxisType": ("Time",),
+        "axis": ("T",)
+        },
+    "time": {
+        "standard_name": ("time",),
+        }
 }
 
 # "long_name" and "standard_name" criteria are the same. For convenience.
-coordinate_criteria["long_name"] = copy.deepcopy(coordinate_criteria["standard_name"])
-coordinate_criteria["long_name"]["X"] += ("cell index along first dimension",)
-coordinate_criteria["long_name"]["Y"] += ("cell index along second dimension",)
+for coord, attrs in coordinate_criteria.items():
+    coordinate_criteria[coord]["long_name"] = coordinate_criteria[coord]["standard_name"]
+coordinate_criteria["X"]["long_name"] += ("cell index along first dimension",)
+coordinate_criteria["Y"]["long_name"] += ("cell index along second dimension",)
+
 
 #: regular expressions for guess_coord_axis
 regex = {

--- a/cf_xarray/criteria.py
+++ b/cf_xarray/criteria.py
@@ -5,14 +5,13 @@ Copyright (c) 2017 MetPy Developers.
 """
 
 
-import copy
 import re
 from typing import MutableMapping, Tuple
 
 coordinate_criteria: MutableMapping[str, MutableMapping[str, Tuple]] = {
     "latitude": {
         "standard_name": ("latitude",),
-		"units": (
+        "units": (
             "degree_north",
             "degree_N",
             "degreeN",
@@ -20,11 +19,11 @@ coordinate_criteria: MutableMapping[str, MutableMapping[str, Tuple]] = {
             "degrees_N",
             "degreesN",
         ),
-        "_CoordinateAxisType": ("Lat",)
-	},
+        "_CoordinateAxisType": ("Lat",),
+    },
     "longitude": {
         "standard_name": ("longitude",),
-		"units": (
+        "units": (
             "degree_east",
             "degree_E",
             "degreeE",
@@ -32,8 +31,8 @@ coordinate_criteria: MutableMapping[str, MutableMapping[str, Tuple]] = {
             "degrees_E",
             "degreesE",
         ),
-        "_CoordinateAxisType": ("Lon",)
-	},
+        "_CoordinateAxisType": ("Lon",),
+    },
     "Z": {
         "standard_name": (
             "model_level_number",
@@ -49,11 +48,15 @@ coordinate_criteria: MutableMapping[str, MutableMapping[str, Tuple]] = {
             "ocean_sigma_z_coordinate",
             "ocean_double_sigma_coordinate",
         ),
-        "_CoordinateAxisType": ("GeoZ", "Height", "Pressure",),
-        "axis": ("Z",)
+        "_CoordinateAxisType": (
+            "GeoZ",
+            "Height",
+            "Pressure",
+        ),
+        "axis": ("Z",),
     },
     "vertical": {
-        "standard_name":    (
+        "standard_name": (
             "air_pressure",
             "height",
             "depth",
@@ -67,28 +70,26 @@ coordinate_criteria: MutableMapping[str, MutableMapping[str, Tuple]] = {
         "positive": ("up", "down"),
     },
     "X": {
-        "standard_name": ( "projection_x_coordinate",),
+        "standard_name": ("projection_x_coordinate",),
         "_CoordinateAxisType": ("GeoX",),
-        "axis": ("X",)
-        },
+        "axis": ("X",),
+    },
     "Y": {
-        "standard_name": ( "projection_y_coordinate",),
+        "standard_name": ("projection_y_coordinate",),
         "_CoordinateAxisType": ("GeoY",),
-        "axis": ("Y",)
-        },
-    "T": {
-        "standard_name": ("time",),
-        "_CoordinateAxisType": ("Time",),
-        "axis": ("T",)
-        },
+        "axis": ("Y",),
+    },
+    "T": {"standard_name": ("time",), "_CoordinateAxisType": ("Time",), "axis": ("T",)},
     "time": {
         "standard_name": ("time",),
-        }
+    },
 }
 
 # "long_name" and "standard_name" criteria are the same. For convenience.
 for coord, attrs in coordinate_criteria.items():
-    coordinate_criteria[coord]["long_name"] = coordinate_criteria[coord]["standard_name"]
+    coordinate_criteria[coord]["long_name"] = coordinate_criteria[coord][
+        "standard_name"
+    ]
 coordinate_criteria["X"]["long_name"] += ("cell index along first dimension",)
 coordinate_criteria["Y"]["long_name"] += ("cell index along second dimension",)
 

--- a/cf_xarray/scripts/make_doc.py
+++ b/cf_xarray/scripts/make_doc.py
@@ -37,7 +37,7 @@ def make_criteria_csv():
 
     # Axes and coordinates
     for keys, name in zip([_AXIS_NAMES, _COORD_NAMES], ["axes", "coords"]):
-        subdf = df.loc[sorted(keys)].dropna(1, how="all")
+        subdf = df[sorted(keys)].dropna(1, how="all")
         subdf = subdf.dropna(1, how="all").transpose()
         subdf.to_csv(os.path.join(csv_dir, f"{name}_criteria.csv"))
 


### PR DESCRIPTION
These changes are in support of updating the `_get_axis_coord` logic to be a bit more generalized so the same logic can be used to find axis coordinates and to pull out variables (that is a future step).

The coordinate_criteria dictionary in criteria.py is now inverted so the keys are axes and coord names with values of valid attribute types and values.

The function `_get_axis_coord()` was updated to try to account for this change in the `coordinate_criteria` dictionary though it may not be correct quite yet. The tests did not all pass.