### PR TITLE
Added another salinity unit

### DIFF
--- a/cf_xarray/tests/test_units.py
+++ b/cf_xarray/tests/test_units.py
@@ -44,6 +44,12 @@ def test_psu_unit():
     assert str(x.units) == "practical_salinity_unit"
 
 
+def test_1en3_unit():
+    """Test that the 1e-3 salinity unit is changed to psu."""
+    x = units("1e-3")
+    assert str(x.units) == "practical_salinity_unit"
+
+
 def test_percent_units():
     """Test that percent sign units are properly parsed and interpreted."""
     assert str(units("%").units) == "percent"

--- a/cf_xarray/tests/test_units.py
+++ b/cf_xarray/tests/test_units.py
@@ -45,9 +45,9 @@ def test_psu_unit():
 
 
 def test_1en3_unit():
-    """Test that the 1e-3 salinity unit is changed to psu."""
+    """Test that the 1e-3 salinity unit is changed to 1."""
     x = units("1e-3")
-    assert str(x.units) == "practical_salinity_unit"
+    assert str(x.units) == "1"
 
 
 def test_percent_units():

--- a/cf_xarray/units.py
+++ b/cf_xarray/units.py
@@ -41,7 +41,7 @@ units.define(
     "degrees_east = degree = degrees_E = degreesE = degree_east = degree_E = degreeE"
 )
 units.define("@alias meter = gpm")
-units.define("practical_salinity_unit = [] = psu")
+units.define("practical_salinity_unit = [] = psu  = 1 PSS-78 = 1 Practical Salinity Scale 78 = 1.e-3 = 1E-3")
 
 # Enable pint's built-in matplotlib support
 try:

--- a/cf_xarray/units.py
+++ b/cf_xarray/units.py
@@ -15,9 +15,11 @@ from pint import (  # noqa: F401
 )
 
 # Create registry, with preprocessors for UDUNITS-style powers (m2 s-2) and percent signs
+# also change salinity unit 1e-3 to psu
 units = pint.UnitRegistry(
     autoconvert_offset_to_baseunit=True,
     preprocessors=[
+        lambda string: string.replace("1e-3", "psu"),
         functools.partial(
             re.compile(
                 r"(?<=[A-Za-z])(?![A-Za-z])(?<![0-9\-][eE])(?<![0-9\-])(?=[0-9\-])"
@@ -41,7 +43,7 @@ units.define(
     "degrees_east = degree = degrees_E = degreesE = degree_east = degree_E = degreeE"
 )
 units.define("@alias meter = gpm")
-units.define("practical_salinity_unit = [] = psu  = 1 PSS-78 = 1 Practical Salinity Scale 78 = 1.e-3 = 1E-3")
+units.define("practical_salinity_unit = [] = psu")
 
 # Enable pint's built-in matplotlib support
 try:

--- a/cf_xarray/units.py
+++ b/cf_xarray/units.py
@@ -19,7 +19,7 @@ from pint import (  # noqa: F401
 units = pint.UnitRegistry(
     autoconvert_offset_to_baseunit=True,
     preprocessors=[
-        lambda string: string.replace("1e-3", "psu"),
+        lambda string: string.replace("1e-3", "1"),
         functools.partial(
             re.compile(
                 r"(?<=[A-Za-z])(?![A-Za-z])(?<![0-9\-][eE])(?<![0-9\-])(?=[0-9\-])"


### PR DESCRIPTION
I added another preprocessor (in addition to modifying %) to replace the string "1e-3" with "psu". Also added a test.

I was not able to figure out another way to add the unit because it always interpreted the numbers as a scaling factor and couldn't figure out how to deal with that.

Note that I could instead change 1e-3 to 1, which is more cf-compliant as I understand it. 