### PR TITLE
Add support for flag variables.

### DIFF
--- a/cf_xarray/accessor.py
+++ b/cf_xarray/accessor.py
@@ -924,30 +924,88 @@ class CFAccessor:
             )
 
     def __eq__(self, other):
+        """
+        Compare flag values against `other`.
+
+        `other` must be in the 'flag_meanings' attribute.
+        `other` is mapped to the corresponding value in the 'flag_values' attribute, and then
+        compared.
+        """
         self._assert_valid_other_comparison(other)
         return self._obj == self._flag_dict[other]
 
     def __ne__(self, other):
+        """
+        Compare flag values against `other`.
+
+        `other` must be in the 'flag_meanings' attribute.
+        `other` is mapped to the corresponding value in the 'flag_values' attribute, and then
+        compared.
+        """
         self._assert_valid_other_comparison(other)
         return self._obj != self._flag_dict[other]
 
     def __lt__(self, other):
+        """
+        Compare flag values against `other`.
+
+        `other` must be in the 'flag_meanings' attribute.
+        `other` is mapped to the corresponding value in the 'flag_values' attribute, and then
+        compared.
+        """
         self._assert_valid_other_comparison(other)
         return self._obj < self._flag_dict[other]
 
     def __le__(self, other):
+        """
+        Compare flag values against `other`.
+
+        `other` must be in the 'flag_meanings' attribute.
+        `other` is mapped to the corresponding value in the 'flag_values' attribute, and then
+        compared.
+        """
         self._assert_valid_other_comparison(other)
         return self._obj <= self._flag_dict[other]
 
     def __gt__(self, other):
+        """
+        Compare flag values against `other`.
+
+        `other` must be in the 'flag_meanings' attribute.
+        `other` is mapped to the corresponding value in the 'flag_values' attribute, and then
+        compared.
+        """
         self._assert_valid_other_comparison(other)
         return self._obj > self._flag_dict[other]
 
     def __ge__(self, other):
+        """
+        Compare flag values against `other`.
+
+        `other` must be in the 'flag_meanings' attribute.
+        `other` is mapped to the corresponding value in the 'flag_values' attribute, and then
+        compared.
+        """
         self._assert_valid_other_comparison(other)
         return self._obj >= self._flag_dict[other]
 
     def isin(self, test_elements):
+        """Test each value in the array for whether it is in test_elements.
+
+        Parameters
+        ----------
+        test_elements : array_like, 1D
+            The values against which to test each value of `element`.
+            These must be in "flag_meanings" attribute, and are mapped
+            to the corresponding value in "flag_values" before passing
+            that on to DataArray.isin.
+
+
+        Returns
+        -------
+        isin : DataArray
+            Has the same type and shape as this object, but with a bool dtype.
+        """
         if self._flag_dict:
             mapped_test_elements = [self._flag_dict[elem] for elem in test_elements]
             return self._obj.isin(mapped_test_elements)

--- a/cf_xarray/accessor.py
+++ b/cf_xarray/accessor.py
@@ -927,6 +927,10 @@ class CFAccessor:
         self._assert_valid_other_comparison(other)
         return self._obj == self._flag_dict[other]
 
+    def __ne__(self, other):
+        self._assert_valid_other_comparison(other)
+        return self._obj != self._flag_dict[other]
+
     def __lt__(self, other):
         self._assert_valid_other_comparison(other)
         return self._obj < self._flag_dict[other]

--- a/cf_xarray/accessor.py
+++ b/cf_xarray/accessor.py
@@ -886,56 +886,12 @@ class _CFWrappedPlotMethods:
         )
 
 
-class CFFlagVariable:
-    def __init__(self, da):
-        self._da = da
-
-        if "flag_meanings" not in da.attrs:
-            raise ValueError(
-                "The flag_meanings attribute is absent. This is not a flag variable."
-            )
-        if "flag_values" not in da.attrs:
-            raise ValueError(
-                "The flag_values attribute is absent. This is not a flag variable."
-            )
-        flag_meanings = da.attrs["flag_meanings"].split(" ")
-        flag_values = da.attrs["flag_values"]
-        # TODO: assert flag_values is iterable
-        assert len(flag_values) == len(flag_meanings)
-        self.flag_dict = dict(zip(flag_meanings, flag_values))
-
-    def _assert_valid_other_comparison(self, other):
-        if other not in self.flag_dict:
-            raise ValueError(
-                f"Did not find flag value meaning [{other}] in known flag meanings: [{self.flag_dict.keys()!r}]"
-            )
-
-    def __eq__(self, other):
-        self._assert_valid_other_comparison(other)
-        return self._da == self.flag_dict[other]
-
-    def __lt__(self, other):
-        self._assert_valid_other_comparison(other)
-        return self._da < self.flag_dict[other]
-
-    def __le__(self, other):
-        self._assert_valid_other_comparison(other)
-        return self._da <= self.flag_dict[other]
-
-    def __gt__(self, other):
-        self._assert_valid_other_comparison(other)
-        return self._da > self.flag_dict[other]
-
-    def __ge__(self, other):
-        self._assert_valid_other_comparison(other)
-        return self._da >= self.flag_dict[other]
-
-    def isin(self, test_elements):
-        mapped_test_elements = [self.flag_dict[elem] for elem in test_elements]
-        return self._da.isin(mapped_test_elements)
-
-    def __repr__(self):
-        return f"CF Flag variable with mapping:\n\t{self.flag_dict!r}"
+def parse_flag_attrs(da):
+    flag_meanings = da.attrs["flag_meanings"].split(" ")
+    flag_values = da.attrs["flag_values"]
+    # TODO: assert flag_values is iterable
+    assert len(flag_values) == len(flag_meanings)
+    return dict(zip(flag_meanings, flag_values))
 
 
 class CFAccessor:
@@ -947,8 +903,54 @@ class CFAccessor:
         self._obj = obj
         self._all_cell_measures = None
 
-        if isinstance(self._obj, xr.DataArray):
-            self.flag = CFFlagVariable(self._obj)
+        if (
+            isinstance(self._obj, xr.DataArray)
+            and "flag_meanings" in self._obj.attrs
+            and "flag_values" in self._obj.attrs
+        ):
+            self._flag_dict = parse_flag_attrs(self._obj)
+        else:
+            self._flag_dict = None
+
+    def _assert_valid_other_comparison(self, other):
+        if not self._flag_dict:
+            raise ValueError(
+                "Comparisons are only supported for DataArrays that represent CF flag variables."
+                ".attrs must contain 'flag_values' and 'flag_meanings'"
+            )
+        if other not in self._flag_dict:
+            raise ValueError(
+                f"Did not find flag value meaning [{other}] in known flag meanings: [{self._flag_dict.keys()!r}]"
+            )
+
+    def __eq__(self, other):
+        self._assert_valid_other_comparison(other)
+        return self._obj == self._flag_dict[other]
+
+    def __lt__(self, other):
+        self._assert_valid_other_comparison(other)
+        return self._obj < self._flag_dict[other]
+
+    def __le__(self, other):
+        self._assert_valid_other_comparison(other)
+        return self._obj <= self._flag_dict[other]
+
+    def __gt__(self, other):
+        self._assert_valid_other_comparison(other)
+        return self._obj > self._flag_dict[other]
+
+    def __ge__(self, other):
+        self._assert_valid_other_comparison(other)
+        return self._obj >= self._flag_dict[other]
+
+    def isin(self, test_elements):
+        if self._flag_dict:
+            mapped_test_elements = [self._flag_dict[elem] for elem in test_elements]
+            return self._obj.isin(mapped_test_elements)
+        else:
+            raise ValueError(
+                ".cf.isin only supported DataArrays that represent CF flag variables. Please use Dataset.isin instead"
+            )
 
     def _get_all_cell_measures(self):
         """
@@ -1106,10 +1108,6 @@ class CFAccessor:
         return kwargs
 
     def __getattr__(self, attr):
-        if attr == "flag":
-            raise AttributeError(
-                "Flag variable features only apply to DataArrays, not Datasets."
-            )
         return _getattr(
             obj=self._obj,
             attr=attr,
@@ -1189,7 +1187,11 @@ class CFAccessor:
 
             return "\n".join(rows) + "\n"
 
-        text = "Coordinates:"
+        if self._flag_dict:
+            text = f"CF Flag variable with mapping:\n\t{self._flag_dict!r}\n\n"
+        else:
+            text = ""
+        text += "Coordinates:"
         text += make_text_section("CF Axes", "axes", coords, _AXIS_NAMES)
         text += make_text_section("CF Coordinates", "coordinates", coords, _COORD_NAMES)
         text += make_text_section(

--- a/cf_xarray/datasets.py
+++ b/cf_xarray/datasets.py
@@ -279,3 +279,15 @@ forecast = xr.decode_cf(
         }
     )
 )
+
+
+basin = xr.DataArray(
+    [1, 2, 1, 1, 2, 2, 3, 3, 3, 3],
+    dims=("time",),
+    attrs={
+        "flag_values": [1, 2, 3],
+        "flag_meanings": "atlantic_ocean pacific_ocean indian_ocean",
+        "standard_name": "region",
+    },
+    name="basin",
+)

--- a/cf_xarray/tests/test_accessor.py
+++ b/cf_xarray/tests/test_accessor.py
@@ -129,6 +129,9 @@ def test_repr():
     """
     assert actual == dedent(expected)
 
+    # Flag DataArray
+    assert "CF Flag variable" in repr(basin.cf)
+
 
 def test_axes():
     expected = dict(T=["time"], X=["lon"], Y=["lat"])

--- a/cf_xarray/tests/test_accessor.py
+++ b/cf_xarray/tests/test_accessor.py
@@ -1403,3 +1403,22 @@ def test_flag_isin():
     actual = basin.cf.isin(["atlantic_ocean", "pacific_ocean"])
     expected = basin.isin([1, 2])
     assert_identical(actual, expected)
+
+
+def test_flag_errors():
+    with pytest.raises(ValueError):
+        basin.cf.isin(["arctic_ocean"])
+
+    with pytest.raises(ValueError):
+        basin.cf == "arctic_ocean"
+
+    ds = xr.Dataset({"basin": basin})
+    with pytest.raises(ValueError):
+        ds.cf.isin(["atlantic_ocean"])
+
+    basin.attrs.pop("flag_values")
+    with pytest.raises(ValueError):
+        basin.cf.isin(["pacific_ocean"])
+
+    with pytest.raises(ValueError):
+        basin.cf == "pacific_ocean"

--- a/cf_xarray/tests/test_accessor.py
+++ b/cf_xarray/tests/test_accessor.py
@@ -17,6 +17,7 @@ from cf_xarray.utils import parse_cf_standard_name_table
 from ..datasets import (
     airds,
     anc,
+    basin,
     ds_no_attrs,
     forecast,
     mollwds,
@@ -1389,3 +1390,16 @@ def test_add_canonical_attributes(override, skip, verbose, capsys):
 
         cf_da.attrs.pop("history")
         assert_identical(cf_da, cf_ds["air"])
+
+
+@pytest.mark.parametrize("op", ["ge", "gt", "eq", "ne", "le", "lt"])
+def test_flag_features(op):
+    actual = getattr(basin.cf, f"__{op}__")("atlantic_ocean")
+    expected = getattr(basin, f"__{op}__")(1)
+    assert_identical(actual, expected)
+
+
+def test_flag_isin():
+    actual = basin.cf.isin(["atlantic_ocean", "pacific_ocean"])
+    expected = basin.isin([1, 2])
+    assert_identical(actual, expected)

--- a/ci/doc.yml
+++ b/ci/doc.yml
@@ -16,6 +16,7 @@ dependencies:
   - ipykernel
   - ipywidgets
   - pandas
+  - pooch
   - pydata-sphinx-theme
   - pip:
       - git+https://github.com/xarray-contrib/cf-xarray

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -52,6 +52,24 @@ Methods
     DataArray.cf.keys
     DataArray.cf.rename_like
 
+Flag Variables
+++++++++++++++
+
+cf_xarray supports rich comparisons for `CF flag variables`_. Flag masks are not yet supported.
+
+.. autosummary::
+   :toctree: generated/
+   :template: autosummary/accessor_method.rst
+
+    DataArray.cf.__lt__
+    DataArray.cf.__le__
+    DataArray.cf.__eq__
+    DataArray.cf.__ne__
+    DataArray.cf.__ge__
+    DataArray.cf.__gt__
+    DataArray.cf.isin
+
+
 Dataset
 -------
 
@@ -92,3 +110,6 @@ Methods
     Dataset.cf.guess_coord_axis
     Dataset.cf.keys
     Dataset.cf.rename_like
+
+
+.. _`CF flag variables`: http://cfconventions.org/Data/cf-conventions/cf-conventions-1.8/cf-conventions.html#flags

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -31,6 +31,7 @@ Attributes
     DataArray.cf.cell_measures
     DataArray.cf.coordinates
     DataArray.cf.formula_terms
+    DataArray.cf.is_flag_variable
     DataArray.cf.standard_names
     DataArray.cf.plot
 

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -7,6 +7,8 @@ v0.6.1 (unreleased)
 ===================
 - Support detecting pint-backed Variables with units-based criteria. By `Deepak Cherian`_.
 - Support reshaping nD bounds arrays to (n-1)D vertex arrays. By `Deepak Cherian`_.
+- Support rich comparisons and ``.isin`` for flag variables using ``DataArray.cf.flag``.
+  By `Deepak Cherian`_ and `Julius Busecke`_
 
 v0.6.0 (June 29, 2021)
 ======================
@@ -125,3 +127,4 @@ v0.1.3
 .. _`Filipe Fernandes`: https://github.com/ocefpaf
 .. _`Julia Kent`: https://github.com/jukent
 .. _`Kristen Thyng`: https://github.com/kthyng
+.. _`Julius Busecke`: https://github.com/jbusecke

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -7,7 +7,7 @@ v0.6.1 (unreleased)
 ===================
 - Support detecting pint-backed Variables with units-based criteria. By `Deepak Cherian`_.
 - Support reshaping nD bounds arrays to (n-1)D vertex arrays. By `Deepak Cherian`_.
-- Support rich comparisons and ``.isin`` for flag variables with ``DataArray.cf``.
+- Support rich comparisons  with ``DataArray.cf`` and :py:meth:`DataArray.cf.isin` for `flag variables`_.
   By `Deepak Cherian`_ and `Julius Busecke`_
 
 v0.6.0 (June 29, 2021)
@@ -128,3 +128,4 @@ v0.1.3
 .. _`Julia Kent`: https://github.com/jukent
 .. _`Kristen Thyng`: https://github.com/kthyng
 .. _`Julius Busecke`: https://github.com/jbusecke
+.. _`flag variables`: http://cfconventions.org/Data/cf-conventions/cf-conventions-1.8/cf-conventions.html#flags

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -7,7 +7,7 @@ v0.6.1 (unreleased)
 ===================
 - Support detecting pint-backed Variables with units-based criteria. By `Deepak Cherian`_.
 - Support reshaping nD bounds arrays to (n-1)D vertex arrays. By `Deepak Cherian`_.
-- Support rich comparisons and ``.isin`` for flag variables using ``DataArray.cf.flag``.
+- Support rich comparisons and ``.isin`` for flag variables with ``DataArray.cf``.
   By `Deepak Cherian`_ and `Julius Busecke`_
 
 v0.6.0 (June 29, 2021)


### PR DESCRIPTION
xref #199
Implements rich comparisons and .isin. I changed my mind and dropped the `.flag`.

@jbusecke I copied your code over but had to make some changes to match the conventions. Try it out and let me know how it works!

``` python
import cf_xarray
import numpy as np
import xarray as xr

da = xr.DataArray(
    [1, 2, 1, 1, 2, 2, 3, 3, 3, 3],
    dims=("time",),
    attrs={
        "flag_values": [1, 2, 3],
        "flag_meanings": "atlantic_ocean pacific_ocean indian_ocean",
		"standard_name": "region",
    },
	name="region",
)
da.cf
```
```
CF Flag variable with mapping:
	{'atlantic_ocean': 1, 'pacific_ocean': 2, 'indian_ocean': 3}

Coordinates:
- CF Axes:   X, Y, Z, T: n/a

- CF Coordinates:   longitude, latitude, vertical, time: n/a

- Cell Measures:   area, volume: n/a

- Standard Names:   n/a

- Bounds:   n/a
```

```python
da.cf == "atlantic_ocean"
```
```
<xarray.DataArray 'basin' (time: 10)>
array([ True, False,  True,  True, False, False, False, False, False,
       False])
Dimensions without coordinates: time
```

``` python
da.cf.isin(["indian_ocean", "pacific_ocean"])
```
```
<xarray.DataArray 'basin' (time: 10)>
array([False,  True, False, False,  True,  True,  True,  True,  True,
        True])
Dimensions without coordinates: time
```

Quoting the docs:
> The `flag_values` attribute is the same type as the variable to which it is attached, and contains a list of the possible flag values. The `flag_meanings` attribute is a string whose value is a blank separated list of descriptive words or phrases, one for each flag value. 