### PR TITLE
Add attribute tracking functionality

### DIFF
--- a/cf_xarray/__init__.py
+++ b/cf_xarray/__init__.py
@@ -1,6 +1,8 @@
+from . import tracking  # noqa
 from .accessor import CFAccessor  # noqa
 from .helpers import bounds_to_vertices, vertices_to_bounds  # noqa
 from .options import set_options  # noqa
+from .tracking import track_cf_attributes  # noqa
 from .utils import _get_version
 
 __version__ = _get_version()

--- a/cf_xarray/tracking.py
+++ b/cf_xarray/tracking.py
@@ -1,0 +1,68 @@
+# This module provides functions for adding CF attribtues
+# and tracking history, provenance using xarray's keep_attrs
+# functionality
+
+import copy
+import functools
+
+CELL_METHODS = {
+    "sum": "sum",
+    "max": "maximum",
+    "min": "minimum",
+    "median": "median",
+    "mean": "mean",
+    "std": "standard_deviation",
+    "var": "variance",
+}
+
+
+def add_cell_methods(attrs, context):
+    """Add appropriate cell_methods attribute."""
+    assert len(attrs) == 1
+    cell_methods = attrs[0].get("cell_methods", "")
+    # TODO: get dim_name from context
+    return {"cell_methods": f"dim_name: {CELL_METHODS[context.func]} {cell_methods}"}
+
+
+def add_history(attrs, context):
+    return {"history": None}
+
+
+def _tracker(
+    attrs,
+    context,
+    strict: bool = False,
+    cell_methods: bool = True,
+    history: bool = True,
+):
+
+    # can only handle single variable attrs for now
+    assert len(attrs) == 1
+    attrs_out = copy.deepcopy(attrs[0])
+
+    if cell_methods and context.func in CELL_METHODS:
+        attrs_out.update(add_cell_methods(attrs, context))
+    if history:
+        attrs_out.update(add_history(attrs, context))
+        pass
+    return attrs_out
+
+
+def track_cf_attributes(
+    *, strict: bool = False, cell_methods: bool = True, history: bool = True
+):
+    """Top-level user-facing function.
+
+    Parameters
+    ----------
+    strict: bool
+        Controls if an error is raised when an appropriate attribute cannot
+        be added because of lack of information.
+    cell_methods: bool
+        Add cell_methods attribute when possible
+    history: bool
+        Adds a history attribute like NCO and follows the NUG convention.
+    """
+    return functools.partial(
+        _tracker, strict=strict, cell_methods=cell_methods, history=history
+    )


### PR DESCRIPTION
Simple test of https://github.com/pydata/xarray/pull/5668 (cc @keewis)

This just adds the `cell_methods` attribute for reductions and a placeholder for tracking history.

``` python
import cf_xarray as cfxr
import xarray as xr

da = xr.DataArray([1, 2, 3], dims="time")
with xr.set_options(keep_attrs=cfxr.track_cf_attributes(cell_methods=True)):
    print(da.mean("time").attrs)
```

```
{'cell_methods': 'dim_name: mean ', 'history': None}
```

There is one top-level function
```
cfxr.tracking.track_cf_attributes(cell_methods=True, history=True)
```
This returns a partial function that can be provided to `keep_attrs` i.e. it expects the args `attrs, context`. I think we could add things like `provenance=True` etc. in the future. 

Right now only the private `_tracker` function satisfies the contract expected by `keep_attrs`. Alternately, we could provide `track_cell_methods` `track_history` etc. that satisfy the contract so that users can instead do for fine control
```
xr.set_options(keep_attrs=cfxr.tracking.track_history)
```

I'm interested in opinions on whether we should do this second approach instead.

cc @huard @aulemahal