### PR TITLE
Fix bounds_to_vertices

### DIFF
--- a/cf_xarray/helpers.py
+++ b/cf_xarray/helpers.py
@@ -90,7 +90,7 @@ def _bounds_helper(values, n_core_dims, nbounds, order):
             top_left = values[..., -1:, :, 3]
             vertex_vals = np.block([[bot_left, bot_right], [top_left, top_right]])
         if order is None:  # We verify if the ccw version works.
-            calc_bnds = vertices_to_bounds(vertex_vals).values
+            calc_bnds = np.moveaxis(vertices_to_bounds(vertex_vals).values, 0, -1)
             order = "counterclockwise" if np.all(calc_bnds == values) else "clockwise"
         if order == "clockwise":
             bot_left = values[..., :, :, 0]

--- a/cf_xarray/tests/test_helpers.py
+++ b/cf_xarray/tests/test_helpers.py
@@ -18,8 +18,14 @@ def test_bounds_to_vertices():
     assert_array_equal(ds.lat.values + 1.25, lat_c.values[:-1])
 
     # 2D case, CF- order
-    lat_c = cfxr.bounds_to_vertices(mollwds.lat_bounds, bounds_dim="bounds")
-    assert_equal(mollwds.lat_vertices, lat_c)
+    lat_ccw = cfxr.bounds_to_vertices(
+        mollwds.lat_bounds, bounds_dim="bounds", order="counterclockwise"
+    )
+    lat_no = cfxr.bounds_to_vertices(
+        mollwds.lat_bounds, bounds_dim="bounds", order=None
+    )
+    assert_equal(mollwds.lat_vertices, lat_ccw)
+    assert_equal(lat_no, lat_ccw)
 
     # Transposing the array changes the bounds direction
     ds = mollwds.transpose("bounds", "y", "x", "y_vertices", "x_vertices")


### PR DESCRIPTION
The recent changes to `bounds_to_vertices` (#250) broke the case where `order=None` and `"counterclockwise"` is the good solution. (The tests were testing the case where `order=None` and solution is `"clockwise"`) We realized it in xESMF : pangeo-data/xESMF#112.

I missed that during my review, but the problem is simply a change in the axes order within the function... This adds a test and fixes the bug.