### PR TITLE
Drop missing variables

### DIFF
--- a/cf_xarray/accessor.py
+++ b/cf_xarray/accessor.py
@@ -1033,6 +1033,10 @@ class CFAccessor:
             mapped_test_elements.append(flag_dict[elem])
         return self._obj.isin(mapped_test_elements)
 
+    def _drop_missing_variables(self, variables: List[str]) -> List[str]:
+
+        return [var for var in variables if var in self._obj]
+
     def _get_all_cell_measures(self):
         """
         Get all cell measures defined in the object, adding CF pre-defined measures.
@@ -1874,10 +1878,6 @@ class CFDatasetAccessor(CFAccessor):
         is a limitation of the xarray data model.
         """
         return _getitem(self, key)
-
-    def _drop_missing_variables(self, variables: List[str]) -> List[str]:
-
-        return [var for var in variables if var in self._obj]
 
     @property
     def formula_terms(self) -> Dict[str, Dict[str, str]]:

--- a/cf_xarray/accessor.py
+++ b/cf_xarray/accessor.py
@@ -1875,10 +1875,9 @@ class CFDatasetAccessor(CFAccessor):
         """
         return _getitem(self, key)
 
-    def _drop_missing_variables(self, variables):
+    def _drop_missing_variables(self, variables: List[str]) -> List[str]:
 
-        names = [var.name if isinstance(var, DataArray) else var for var in variables]
-        return [var for name, var in zip(names, variables) if name in self._obj]
+        return [var for var in variables if var in self._obj]
 
     @property
     def formula_terms(self) -> Dict[str, Dict[str, str]]:

--- a/cf_xarray/accessor.py
+++ b/cf_xarray/accessor.py
@@ -1883,9 +1883,15 @@ class CFDatasetAccessor(CFAccessor):
         Property that returns a dictionary
             {parametric_coord_name: {standard_term_name: variable_name}}
         """
-        return {
-            dim: self._obj[dim].cf.formula_terms for dim in _get_dims(self._obj, "Z")
-        }
+        results = {}
+        for dim in _get_dims(self._obj, "Z"):
+            terms = self._obj[dim].cf.formula_terms
+            variables = self._drop_missing_variables(list(terms.values()))
+            terms = {key: val for key, val in terms.items() if val in variables}
+            if terms:
+                results[dim] = terms
+
+        return results
 
     @property
     def bounds(self) -> Dict[str, List[str]]:

--- a/cf_xarray/accessor.py
+++ b/cf_xarray/accessor.py
@@ -1035,7 +1035,7 @@ class CFAccessor:
 
     def _drop_missing_variables(self, variables: List[str]) -> List[str]:
 
-        return [var for var in variables if var in self._obj]
+        return [var for var in variables if var in self._obj or var in self._obj.coords]
 
     def _get_all_cell_measures(self):
         """
@@ -1391,7 +1391,9 @@ class CFAccessor:
         keys = {}
         for attr in all_attrs:
             keys.update(parse_cell_methods_attr(attr))
-        measures = {key: _get_all(self._obj, key) for key in keys}
+        measures = {
+            key: self._drop_missing_variables(_get_all(self._obj, key)) for key in keys
+        }
 
         return {k: sorted(set(v)) for k, v in measures.items() if v}
 

--- a/cf_xarray/tests/test_accessor.py
+++ b/cf_xarray/tests/test_accessor.py
@@ -177,7 +177,7 @@ def test_cell_measures():
     ds["air"].attrs["cell_measures"] += " volume: foo"
     ds["foo"].attrs["cell_measures"] = ds["air"].attrs["cell_measures"]
     expected = dict(area=["cell_area"], foo_measure=["foo"], volume=["foo"])
-    actual_air = ds["air"].cf.cell_measures
+    actual_air = ds.cf["air"].cf.cell_measures
     actual_foo = ds.cf["foo_measure"].cf.cell_measures
     assert actual_air == actual_foo == expected
 
@@ -1453,11 +1453,17 @@ def test_flag_errors():
         basin.cf == "pacific_ocean"
 
 
-def test_missing_bounds():
+def test_missing_variables():
 
+    # Bounds
     ds = mollwds.copy(deep=True)
     ds = ds.drop("lon_bounds")
     assert "lon_bounds" not in sum(ds.cf.bounds.values(), [])
 
     with pytest.raises(KeyError, match=r"No results found for 'longitude'."):
         ds.cf.get_bounds("longitude")
+
+    # Cell measures
+    ds = airds.copy(deep=True)
+    ds = ds.drop("cell_area")
+    assert "area" not in ds.cf.cell_measures

--- a/cf_xarray/tests/test_accessor.py
+++ b/cf_xarray/tests/test_accessor.py
@@ -177,7 +177,7 @@ def test_cell_measures():
     ds["air"].attrs["cell_measures"] += " volume: foo"
     ds["foo"].attrs["cell_measures"] = ds["air"].attrs["cell_measures"]
     expected = dict(area=["cell_area"], foo_measure=["foo"], volume=["foo"])
-    actual_air = ds["air"].cf.cell_measures
+    actual_air = ds.cf["air"].cf.cell_measures
     actual_foo = ds.cf["foo_measure"].cf.cell_measures
     assert actual_air == actual_foo == expected
 

--- a/cf_xarray/tests/test_accessor.py
+++ b/cf_xarray/tests/test_accessor.py
@@ -1458,7 +1458,7 @@ def test_missing_variables():
     # Bounds
     ds = mollwds.copy(deep=True)
     ds = ds.drop("lon_bounds")
-    assert "lon_bounds" not in sum(ds.cf.bounds.values(), [])
+    assert ds.cf.bounds == {"lat": ["lat_bounds"], "latitude": ["lat_bounds"]}
 
     with pytest.raises(KeyError, match=r"No results found for 'longitude'."):
         ds.cf.get_bounds("longitude")
@@ -1466,4 +1466,9 @@ def test_missing_variables():
     # Cell measures
     ds = airds.copy(deep=True)
     ds = ds.drop("cell_area")
-    assert "area" not in ds.cf.cell_measures
+    assert ds.cf.cell_measures == {}
+
+    # Formula terms
+    ds = vert.copy(deep=True)
+    ds = ds.drop("ap")
+    assert ds.cf.formula_terms == {"lev": {"b": "b", "ps": "ps"}}

--- a/cf_xarray/tests/test_accessor.py
+++ b/cf_xarray/tests/test_accessor.py
@@ -1451,3 +1451,13 @@ def test_flag_errors():
 
     with pytest.raises(ValueError):
         basin.cf == "pacific_ocean"
+
+
+def test_missing_bounds():
+
+    ds = mollwds.copy(deep=True)
+    ds = ds.drop("lon_bounds")
+    assert "lon_bounds" not in sum(ds.cf.bounds.values(), [])
+
+    with pytest.raises(KeyError, match=r"No results found for 'longitude'."):
+        ds = ds.cf.get_bounds("longitude")

--- a/cf_xarray/tests/test_accessor.py
+++ b/cf_xarray/tests/test_accessor.py
@@ -1460,4 +1460,4 @@ def test_missing_bounds():
     assert "lon_bounds" not in sum(ds.cf.bounds.values(), [])
 
     with pytest.raises(KeyError, match=r"No results found for 'longitude'."):
-        ds = ds.cf.get_bounds("longitude")
+        ds.cf.get_bounds("longitude")

--- a/cf_xarray/tests/test_accessor.py
+++ b/cf_xarray/tests/test_accessor.py
@@ -177,7 +177,7 @@ def test_cell_measures():
     ds["air"].attrs["cell_measures"] += " volume: foo"
     ds["foo"].attrs["cell_measures"] = ds["air"].attrs["cell_measures"]
     expected = dict(area=["cell_area"], foo_measure=["foo"], volume=["foo"])
-    actual_air = ds.cf["air"].cf.cell_measures
+    actual_air = ds["air"].cf.cell_measures
     actual_foo = ds.cf["foo_measure"].cf.cell_measures
     assert actual_air == actual_foo == expected
 


### PR DESCRIPTION
Closes #254 

I haven't tried with other attributes, but it looks like introducing a decorator that only returns existing keys would work well.
Thoughts? If you think that this is the way to go, I'll try to implement it for `cell_measures`, `formula_terms`, ...

cc: @dcherian @tomvothecoder @huard 