### PR TITLE
Allow hashable keys (not only strings) 

### DIFF
--- a/cf_xarray/accessor.py
+++ b/cf_xarray/accessor.py
@@ -89,10 +89,10 @@ def apply_mapper(
     results for a good key.
     """
 
-    if not isinstance(key, collections.abc.Hashable):
+    if not isinstance(key, Hashable):
         if default is None:
             raise ValueError(
-                "`default` must be provided when `key` is not hashable (not a valid DataArray name)."
+                "`default` must be provided when `key` is not not a valid DataArray name (of hashable type)."
             )
         return list(always_iterable(default))
 

--- a/cf_xarray/accessor.py
+++ b/cf_xarray/accessor.py
@@ -1,4 +1,3 @@
-import collections.abc
 import functools
 import inspect
 import itertools

--- a/cf_xarray/accessor.py
+++ b/cf_xarray/accessor.py
@@ -1,3 +1,4 @@
+import collections.abc
 import functools
 import inspect
 import itertools
@@ -76,7 +77,7 @@ F = TypeVar("F", bound=Callable[..., Any])
 def apply_mapper(
     mappers: Union[Mapper, Tuple[Mapper, ...]],
     obj: Union[DataArray, Dataset],
-    key: Any,
+    key: Hashable,
     error: bool = True,
     default: Any = None,
 ) -> List[Any]:
@@ -88,9 +89,11 @@ def apply_mapper(
     results for a good key.
     """
 
-    if not isinstance(key, str):
+    if not isinstance(key, collections.abc.Hashable):
         if default is None:
-            raise ValueError("`default` must be provided when `key` is not a string.")
+            raise ValueError(
+                "`default` must be provided when `key` is not hashable (not a valid DataArray name)."
+            )
         return list(always_iterable(default))
 
     default = [] if default is None else list(always_iterable(default))

--- a/cf_xarray/tests/test_accessor.py
+++ b/cf_xarray/tests/test_accessor.py
@@ -134,6 +134,38 @@ def test_repr():
     # Flag DataArray
     assert "CF Flag variable" in repr(basin.cf)
 
+    # "Temp" dataset
+    actual = airds["air"]._to_temp_dataset().cf.__repr__()
+    expected = """\
+    Coordinates:
+    - CF Axes: * X: ['lon']
+               * Y: ['lat']
+               * T: ['time']
+                 Z: n/a
+
+    - CF Coordinates: * longitude: ['lon']
+                      * latitude: ['lat']
+                      * time: ['time']
+                        vertical: n/a
+
+    - Cell Measures:   area: ['cell_area']
+                       volume: n/a
+
+    - Standard Names: * latitude: ['lat']
+                      * longitude: ['lon']
+                      * time: ['time']
+
+    - Bounds:   n/a
+
+    Data Variables:
+    - Cell Measures:   area, volume: n/a
+
+    - Standard Names:   air_temperature: [<this-array>]
+
+    - Bounds:   n/a
+    """
+    assert actual == dedent(expected)
+
 
 def test_axes():
     expected = dict(T=["time"], X=["lon"], Y=["lat"])

--- a/cf_xarray/tests/test_accessor.py
+++ b/cf_xarray/tests/test_accessor.py
@@ -1110,7 +1110,7 @@ def test_drop_vars_and_set_coords(obj, attr):
     # Cell measure
     assert_identical(expected("cell_area"), actual("area"))
     # Variables
-    if isinstance(obj, Dataset):
+    if isinstance(obj, Dataset) and "air" in obj.data_vars:
         assert_identical(expected("air"), actual("air_temperature"))
         assert_identical(expected(obj.variables), actual(obj.cf.keys()))
 
@@ -1126,7 +1126,7 @@ def test_drop_sel_and_reset_coords(obj):
     # Cell measure
     assert_identical(obj.reset_coords("cell_area"), obj.cf.reset_coords("area"))
     # Variable
-    if isinstance(obj, Dataset):
+    if isinstance(obj, Dataset) and "air" in obj.data_vars:
         assert_identical(
             obj.reset_coords("air"), obj.cf.reset_coords("air_temperature")
         )
@@ -1150,7 +1150,11 @@ def test_rename(obj):
     cf_dict = {
         "air_temperature" if isinstance(obj, Dataset) else "longitude": "renamed"
     }
-    xr_dict = {"air" if isinstance(obj, Dataset) else "lon": "renamed"}
+    xr_dict = {
+        "air"
+        if isinstance(obj, Dataset) and "air" in obj.data_vars
+        else "lon": "renamed"
+    }
     assert_identical(obj.rename(xr_dict), obj.cf.rename(cf_dict))
     assert_identical(obj.rename(**xr_dict), obj.cf.rename(**cf_dict))
 


### PR DESCRIPTION
Fixes #229.

I modified `apply_mapper` to fit with xarray's criterion for a `DataArray` name, meaning that `key` must be hashable (and not only simply a string). I added a test for the `_to_temp_dataset()` case. All other tests pass.

As far as I understand, the `key` is tested either against string parsed from the attributes or against variable names in the dataset. In the first case, passing a non-string doesn't raise anything but it's also useless. In the second case, that's precisely the point : "being hashable" is the same constraint as in xarray.

But maybe others have a better idea of the edge cases? I can add more tests, I just don't know what to test!