### PR TITLE
Remove pkg resources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ share/python-wheels/
 .installed.cfg
 *.egg
 MANIFEST
+cf_xarray/_version.py
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,16 @@
 graft cf_xarray/data
+exclude cf_xarray/_version.py
+
+prune ci
+prune doc
+prune *.egg-info
+prune .binder/
+prune .github/
+
+exclude CITATION.cff
+exclude .deepsource.toml
+exclude .tributors
+exclude .zenodo.json
+exclude *.yml
+exclude *.yaml
+exclude .gitignore

--- a/cf_xarray/utils.py
+++ b/cf_xarray/utils.py
@@ -3,7 +3,6 @@ from collections import defaultdict
 from typing import Any, Dict, Iterable
 from xml.etree import ElementTree
 
-from pkg_resources import DistributionNotFound, get_distribution
 from xarray import DataArray
 
 
@@ -94,7 +93,9 @@ def parse_cf_standard_name_table(source=None):
 
 
 def _get_version():
+    __version__ = "unknown"
     try:
-        return get_distribution("cf_xarray").version
-    except DistributionNotFound:
-        return "unknown"
+        from ._version import __version__
+    except ImportError:
+        pass
+    return __version__

--- a/doc/examples/introduction.ipynb
+++ b/doc/examples/introduction.ipynb
@@ -648,9 +648,9 @@
     "## Feature: Rewriting arguments\n",
     "\n",
     "`cf_xarray` can rewrite arguments for a large number of xarray functions. By\n",
-    "this I mean that instead of specifying say `dim=\"lon\"`, you can pass `dim=\"X\"` or\n",
-    "`dim=\"longitude\"` and `cf_xarray` will rewrite that to `dim=\"lon\"` based on the\n",
-    "attributes present in the dataset.\n",
+    "this I mean that instead of specifying say `dim=\"lon\"`, you can pass `dim=\"X\"`\n",
+    "or `dim=\"longitude\"` and `cf_xarray` will rewrite that to `dim=\"lon\"` based on\n",
+    "the attributes present in the dataset.\n",
     "\n",
     "Here are a few examples\n"
    ]

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,6 @@ python_requires = >=3.6
 install_requires =
     numpy >= 1.15
     pandas >= 0.25
-    setuptools >= 41.2  # For pkg_resources
     xarray
 setup_requires =
     setuptools >= 41.2
@@ -42,7 +41,7 @@ skip_gitignore = true
 force_to_top = true
 default_section = THIRDPARTY
 known_first_party = cf_xarray
-known_third_party = dask,matplotlib,numpy,pandas,pint,pkg_resources,pytest,setuptools,sphinx_autosummary_accessors,xarray
+known_third_party = dask,matplotlib,numpy,pandas,pint,pytest,setuptools,sphinx_autosummary_accessors,xarray
 
 # Most of the numerical computing stack doesn't have type annotations yet.
 [mypy-affine.*]

--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,14 @@
 from setuptools import setup
 
 setup(
-    use_scm_version=True,
-    setup_requires=["setuptools_scm"],
+    # The package metadata is specified in setup.cfg but GitHub's downstream dependency graph
+    # does not work unless we put the name this here too.
+    name="cf_xarray",
+    use_scm_version={
+        "write_to": "cf_xarray/_version.py",
+        "write_to_template": '__version__ = "{version}"',
+        "tag_regex": r"^(?P<prefix>v)?(?P<version>[^\+]+)(?P<suffix>.*)?$",
+    },
     description="A lightweight convenience wrapper for using CF attributes on xarray objects. ",
     url="https://cf-xarray.readthedocs.io",
 )


### PR DESCRIPTION
@dcherian this is not ready yet but I want to place it here so I don't forget.

Relying on `pkg_resources` can make the initial import of cf_xarray quite slow depending on the packages you have installed. This PR changes the logic a bit to avoid relying on that but rather make use of  setuptools-scm file `_version.py`.