### PR TITLE
single source for metadata

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,6 +2,7 @@
 name = cf_xarray
 license = Apache
 url = https://github.com/xarray-contrib/cf-xarray
+description = A lightweight convenience wrapper for using CF attributes on xarray objects
 
 [options]
 packages = cf_xarray

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name = cf_xarray
 license = Apache
-url = https://github.com/xarray-contrib/cf-xarray
+url = https://cf-xarray.readthedocs.io
 description = A lightweight convenience wrapper for using CF attributes on xarray objects
 
 [options]

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,4 @@ setup(
         "write_to_template": '__version__ = "{version}"',
         "tag_regex": r"^(?P<prefix>v)?(?P<version>[^\+]+)(?P<suffix>.*)?$",
     },
-    description="A lightweight convenience wrapper for using CF attributes on xarray objects. ",
-    url="https://cf-xarray.readthedocs.io",
 )


### PR DESCRIPTION
@dcherian the URL in the setup.cfg is for the GH repo but the one in the setup.py is for the docs. Which one do you want to keep?