### PR TITLE
Reduce binder size and hopefully make it faster

### DIFF
--- a/.binder/environment.yml
+++ b/.binder/environment.yml
@@ -2,8 +2,8 @@ name: cf_xarray
 channels:
   - conda-forge
 dependencies:
-  - python=3.8
-  - matplotlib
+  - python=3
+  - matplotlib-base
   - netcdf4
   - pip
   - xarray


### PR DESCRIPTION
@dcherian we don't need qt so mpl base should suffice. That reduces the size of the image and make binder load a bit faster.
I also remove the minor pin on Python to let the solver get whatever latest one works with the dependencies. Should be OK for demos.