### PR TITLE
remove the isort seeding hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,5 @@
 # https://pre-commit.com/
 repos:
-  - repo: https://github.com/asottile/seed-isort-config
-    rev: v2.2.0
-    hooks:
-      - id: seed-isort-config
-
   # isort should run before black as black sometimes tweaks the isort output
   - repo: https://github.com/timothycrosley/isort
     rev: 5.9.3


### PR DESCRIPTION
Apparently, the tool has been abandoned by the maintainer: the repository has been archived. Since it is failing I believe it is time to remove it (I don't really understand its purpose so I might be wrong, though)