### PR TITLE
explicitly use the short formatter in the docs

### DIFF
--- a/doc/units.md
+++ b/doc/units.md
@@ -22,5 +22,5 @@ from pint import application_registry as ureg
 import cf_xarray.units
 
 u = ureg.Unit("m ** 3 / s ** 2")
-f"{u:cf}"
+f"{u:~cf}"
 ```


### PR DESCRIPTION
follow-up to #278. Since `pint` doesn't pass the modifier to the formatter at the moment, `":cf"` and `":~cf"` do the same thing right now. Despite that, it's better to add the `~` modifier when talking about the short format. 

Edit: see hgrecco/pint#1448