### PR TITLE
fix cf_xarray.utils._is_datetime_like

### DIFF
--- a/cf_xarray/tests/test_accessor.py
+++ b/cf_xarray/tests/test_accessor.py
@@ -1416,12 +1416,12 @@ def test_add_canonical_attributes_0_dim():
 
 def test_datetime_like():
     """test for 0 or >= 2 time dimensions"""
-    import cftime
-
-    from cf_xarray.utils import _is_datetime_like
-
-    assert _is_datetime_like(xr.DataArray([[cftime.datetime(2022, 1, 12)]]))
-    assert _is_datetime_like(xr.DataArray(cftime.datetime(2022, 1, 12)))
+    da = xr.DataArray(
+        np.timedelta64(1, "D"),
+        attrs={"standard_name": "sea_water_age_since_surface_contact"},
+    )
+    new_attrs = da.cf.add_canonical_attributes().attrs
+    assert "units" not in new_attrs and "description" in new_attrs
 
 
 @pytest.mark.parametrize("override", [True, False])

--- a/cf_xarray/tests/test_accessor.py
+++ b/cf_xarray/tests/test_accessor.py
@@ -1419,8 +1419,8 @@ def test_datetime_like():
     import cftime
     from cf_xarray.utils import _is_datetime_like
 
-    assert _is_datetime_like(xr.DataArray([[cftime.datetime(2022, 1, 12)]])) == True
-    assert _is_datetime_like(xr.DataArray(cftime.datetime(2022, 1, 12))) == True
+    assert _is_datetime_like(xr.DataArray([[cftime.datetime(2022, 1, 12)]]))
+    assert _is_datetime_like(xr.DataArray(cftime.datetime(2022, 1, 12)))
 
 
 @pytest.mark.parametrize("override", [True, False])

--- a/cf_xarray/tests/test_accessor.py
+++ b/cf_xarray/tests/test_accessor.py
@@ -1417,6 +1417,7 @@ def test_add_canonical_attributes_0_dim():
 def test_datetime_like():
     """test for 0 or >= 2 time dimensions"""
     import cftime
+
     from cf_xarray.utils import _is_datetime_like
 
     assert _is_datetime_like(xr.DataArray([[cftime.datetime(2022, 1, 12)]]))

--- a/cf_xarray/tests/test_accessor.py
+++ b/cf_xarray/tests/test_accessor.py
@@ -1406,16 +1406,22 @@ def test_cf_standard_name_table_version():
     actual_info, _, _ = parse_cf_standard_name_table()
     assert expected_info == actual_info
 
+
 def test_add_canonical_attributes_0_dim():
     """test if works for variables with 0 dimension"""
-    xr.DataArray(0, attrs={'standard_name':'sea_water_potential_temperature'}).cf.add_canonical_attributes()
+    xr.DataArray(
+        0, attrs={"standard_name": "sea_water_potential_temperature"}
+    ).cf.add_canonical_attributes()
+
 
 def test_datetime_like():
     """test for 0 or >= 2 time dimensions"""
     import cftime
     from cf_xarray.utils import _is_datetime_like
+
     assert _is_datetime_like(xr.DataArray([[cftime.datetime(2022, 1, 12)]])) == True
     assert _is_datetime_like(xr.DataArray(cftime.datetime(2022, 1, 12))) == True
+
 
 @pytest.mark.parametrize("override", [True, False])
 @pytest.mark.parametrize("skip", ["units", None])

--- a/cf_xarray/tests/test_accessor.py
+++ b/cf_xarray/tests/test_accessor.py
@@ -1406,6 +1406,16 @@ def test_cf_standard_name_table_version():
     actual_info, _, _ = parse_cf_standard_name_table()
     assert expected_info == actual_info
 
+def test_add_canonical_attributes_0_dim():
+    """test if works for variables with 0 dimension"""
+    xr.DataArray(0, attrs={'standard_name':'sea_water_potential_temperature'}).cf.add_canonical_attributes()
+
+def test_datetime_like():
+    """test for 0 or >= 2 time dimensions"""
+    import cftime
+    from cf_xarray.utils import _is_datetime_like
+    assert _is_datetime_like(xr.DataArray([[cftime.datetime(2022, 1, 12)]])) == True
+    assert _is_datetime_like(xr.DataArray(cftime.datetime(2022, 1, 12))) == True
 
 @pytest.mark.parametrize("override", [True, False])
 @pytest.mark.parametrize("skip", ["units", None])

--- a/cf_xarray/utils.py
+++ b/cf_xarray/utils.py
@@ -17,7 +17,7 @@ def _is_datetime_like(da: DataArray) -> bool:
     try:
         import cftime
 
-        if isinstance(da.data[0], cftime.datetime):
+        if isinstance(da.data.__getitem__((0,) * len(da.data.shape)), cftime.datetime):
             return True
     except ImportError:
         pass


### PR DESCRIPTION
Fixes #285 
I added 2 tests to verify this PR, they were not passed before and are now passed.
After a small benchmark, it seems that my proposed solution in #285 is not the fastest. I changed it to another similar solution. 