### PR TITLE
Fix unpickling by defining __setstate__

### DIFF
--- a/cf_xarray/accessor.py
+++ b/cf_xarray/accessor.py
@@ -933,6 +933,9 @@ class CFAccessor:
         self._obj = obj
         self._all_cell_measures = None
 
+    def __setstate__(self, d):
+        self.__dict__ = d
+
     def _assert_valid_other_comparison(self, other):
         flag_dict = create_flag_dict(self._obj)
         if other not in flag_dict:

--- a/cf_xarray/tests/test_accessor.py
+++ b/cf_xarray/tests/test_accessor.py
@@ -1,4 +1,5 @@
 import itertools
+import pickle
 from textwrap import dedent
 from urllib.request import urlopen
 
@@ -1538,3 +1539,10 @@ def test_missing_variables():
     ds = vert.copy(deep=True)
     ds = ds.drop_vars("ap")
     assert ds.cf.formula_terms == {"lev": {"b": "b", "ps": "ps"}}
+
+
+def test_pickle():
+    da = xr.DataArray([1.0], name="a")
+    ds = da.to_dataset()
+    pickle.loads(pickle.dumps(da.cf))
+    pickle.loads(pickle.dumps(ds.cf))


### PR DESCRIPTION
I think this is the problem
1.  __init__ isn't called during unpickling.
2. So self._obj is undefinited and goes through our _getattr machinery
   which requires self._obj as an argument, so we get a RecursionError

For some reason this is only (so far) triggered when stuffing xarray objects
in dask.delayed tasks and a distributed scheduler.

The test of pickling `da.cf` fails on main, so it would be good to fix
that in general.