### PR TITLE
new vertical coord decode and reordering

### DIFF
--- a/cf_xarray/accessor.py
+++ b/cf_xarray/accessor.py
@@ -2190,7 +2190,7 @@ class CFDatasetAccessor(CFAccessor):
                 )
         return obj
 
-    def decode_vertical_coords(self, prefix="z", zname_in=None):
+    def decode_vertical_coords(self, *, outnames=None, prefix=None):
         """
         Decode parameterized vertical coordinates in place.
 

--- a/cf_xarray/accessor.py
+++ b/cf_xarray/accessor.py
@@ -2268,10 +2268,7 @@ class CFDatasetAccessor(CFAccessor):
                     terms["depth_c"] * terms["s"]
                     + (terms["depth"] - terms["depth_c"]) * terms["C"]
                 )
-                # # expand dims so ordering is preserved
-                # terms["eta"] = terms["eta"].expand_dims(
-                #     dim={terms["s"].name: terms["s"]}, axis=1
-                # )
+
                 # z(n,k,j,i) = S(k,j,i) + eta(n,j,i) * (1 + S(k,j,i) / depth(j,i))
                 ztemp = terms["eta"] * (1 + S / terms["depth"]) + S
 
@@ -2281,18 +2278,11 @@ class CFDatasetAccessor(CFAccessor):
                 S = (terms["depth_c"] * terms["s"] + terms["depth"] * terms["C"]) / (
                     terms["depth_c"] + terms["depth"]
                 )
-                # # expand dims so ordering is preserved
-                # terms["eta"] = terms["eta"].expand_dims(
-                #     dim={terms["s"].name: terms["s"]}, axis=1
-                # )
+
                 # z(n,k,j,i) = eta(n,j,i) + (eta(n,j,i) + depth(j,i)) * S(k,j,i)
                 ztemp = terms["eta"] + (terms["eta"] + terms["depth"]) * S
 
             elif stdname == "ocean_sigma_coordinate":
-                # # expand dims so ordering is preserved
-                # terms["eta"] = terms["eta"].expand_dims(
-                #     dim={terms["sigma"].name: terms["sigma"]}, axis=1
-                # )
                 # z(n,k,j,i) = eta(n,j,i) + sigma(k)*(depth(j,i)+eta(n,j,i))
                 ztemp = terms["eta"] + terms["sigma"] * (
                     terms["depth"] + terms["eta"]
@@ -2306,8 +2296,6 @@ class CFDatasetAccessor(CFAccessor):
             # add Axis attribute
             ztemp.attrs['axis'] = 'Z'
             ds.coords[zname] = ztemp
-            # reorder to time x depth x lat/Y x lon/X
-            ds.coords[zname].cf.transpose(*[dim for dim in ["T", "Z", "Y", "X"] if dim in ds.coords[zname].reset_coords(drop=True).cf.axes])
 
 
 @xr.register_dataarray_accessor("cf")

--- a/cf_xarray/accessor.py
+++ b/cf_xarray/accessor.py
@@ -2196,13 +2196,12 @@ class CFDatasetAccessor(CFAccessor):
 
         Parameters
         ----------
+        outnames : dict, optional
+            Keys of outnames are the input sigma/s coordinate variable name and
+            the values are the name to use for the associated vertical coordinate.
         prefix : str, optional
             Prefix for newly created z variables.
             E.g. ``s_rho`` becomes ``z_rho``
-        zname_in : str, optional
-            Name for new z variable, only makes sense to use if there is a single
-            variable being calculated. This is used in place of `prefix` if
-            provided.
 
         Returns
         -------
@@ -2233,11 +2232,14 @@ class CFDatasetAccessor(CFAccessor):
 
         allterms = self.formula_terms
         for dim in allterms:
-            suffix = dim.split("_")
-            if zname_in is None:
-                zname = f"{prefix}_" + "_".join(suffix[1:])
+            if prefix is None:
+                warnings.warn('`prefix` is being deprecated; use `outnames` instead.', DeprecationWarning)
+                # set outnames here
+                zname = outnames[dim]
+
             else:
-                zname = zname_in
+                suffix = dim.split("_")
+                zname = f"{prefix}_" + "_".join(suffix[1:])
 
             if "standard_name" not in ds[dim].attrs:
                 continue

--- a/cf_xarray/accessor.py
+++ b/cf_xarray/accessor.py
@@ -2233,15 +2233,12 @@ class CFDatasetAccessor(CFAccessor):
         allterms = self.formula_terms
         for dim in allterms:
             if prefix is None:
+                assert outnames is not None, 'if prefix is None, outnames must be provided'
                 # set outnames here
-                # need a default name option
-                if outnames is None:
-                    zname = f"z_{dim}"
-                else:
-                    try:
-                        zname = outnames[dim]
-                    except KeyError:
-                        print("Your `outnames` need to include a key of `dim`.")
+                try:
+                    zname = outnames[dim]
+                except KeyError:
+                    print("Your `outnames` need to include a key of `dim`.")
 
             else:
                 warnings.warn(

--- a/cf_xarray/accessor.py
+++ b/cf_xarray/accessor.py
@@ -2233,18 +2233,21 @@ class CFDatasetAccessor(CFAccessor):
         allterms = self.formula_terms
         for dim in allterms:
             if prefix is None:
-                warnings.warn(
-                    "`prefix` is being deprecated; use `outnames` instead.",
-                    DeprecationWarning,
-                )
                 # set outnames here
                 # need a default name option
                 if outnames is None:
                     zname = f"z_{dim}"
                 else:
-                    zname = outnames[dim]
+                    try:
+                        zname = outnames[dim]
+                    except KeyError:
+                        print('Your `outnames` need to include a key of `dim`.')
 
             else:
+                warnings.warn(
+                    "`prefix` is being deprecated; use `outnames` instead.",
+                    DeprecationWarning,
+                )
                 suffix = dim.split("_")
                 zname = f"{prefix}_" + "_".join(suffix[1:])
 
@@ -2295,8 +2298,6 @@ class CFDatasetAccessor(CFAccessor):
                     f"Coordinate function for {stdname!r} not implemented yet. Contributions welcome!"
                 )
 
-            # add Axis attribute
-            ztemp.attrs["axis"] = "Z"
             ds.coords[zname] = ztemp
 
 

--- a/cf_xarray/accessor.py
+++ b/cf_xarray/accessor.py
@@ -2233,7 +2233,9 @@ class CFDatasetAccessor(CFAccessor):
         allterms = self.formula_terms
         for dim in allterms:
             if prefix is None:
-                assert outnames is not None, 'if prefix is None, outnames must be provided'
+                assert (
+                    outnames is not None
+                ), "if prefix is None, outnames must be provided"
                 # set outnames here
                 try:
                     zname = outnames[dim]

--- a/cf_xarray/accessor.py
+++ b/cf_xarray/accessor.py
@@ -2240,7 +2240,7 @@ class CFDatasetAccessor(CFAccessor):
                 try:
                     zname = outnames[dim]
                 except KeyError:
-                    print("Your `outnames` need to include a key of `dim`.")
+                    raise KeyError("Your `outnames` need to include a key of `dim`.")
 
             else:
                 warnings.warn(

--- a/cf_xarray/accessor.py
+++ b/cf_xarray/accessor.py
@@ -2238,7 +2238,11 @@ class CFDatasetAccessor(CFAccessor):
                     DeprecationWarning,
                 )
                 # set outnames here
-                zname = outnames[dim]
+                # need a default name option
+                if outnames is None:
+                    zname = f"z_{dim}"
+                else:
+                    zname = outnames[dim]
 
             else:
                 suffix = dim.split("_")
@@ -2270,7 +2274,7 @@ class CFDatasetAccessor(CFAccessor):
                 )
 
                 # z(n,k,j,i) = S(k,j,i) + eta(n,j,i) * (1 + S(k,j,i) / depth(j,i))
-                ztemp = terms["eta"] * (1 + S / terms["depth"]) + S
+                ztemp = S + terms["eta"] * (1 + S / terms["depth"])
 
             elif stdname == "ocean_s_coordinate_g2":
                 # make sure all necessary terms are present in terms

--- a/cf_xarray/accessor.py
+++ b/cf_xarray/accessor.py
@@ -2241,7 +2241,7 @@ class CFDatasetAccessor(CFAccessor):
                     try:
                         zname = outnames[dim]
                     except KeyError:
-                        print('Your `outnames` need to include a key of `dim`.')
+                        print("Your `outnames` need to include a key of `dim`.")
 
             else:
                 warnings.warn(

--- a/cf_xarray/accessor.py
+++ b/cf_xarray/accessor.py
@@ -2264,7 +2264,9 @@ class CFDatasetAccessor(CFAccessor):
                     + (terms["depth"] - terms["depth_c"]) * terms["C"]
                 )
                 # expand dims so ordering is preserved
-                terms["eta"] = terms["eta"].expand_dims(dim={terms["s"].name: terms["s"]}, axis=1)
+                terms["eta"] = terms["eta"].expand_dims(
+                    dim={terms["s"].name: terms["s"]}, axis=1
+                )
                 # z(n,k,j,i) = S(k,j,i) + eta(n,j,i) * (1 + S(k,j,i) / depth(j,i))
                 ds.coords[zname] = terms["eta"] * (1 + S / terms["depth"]) + S
 
@@ -2275,16 +2277,21 @@ class CFDatasetAccessor(CFAccessor):
                     terms["depth_c"] + terms["depth"]
                 )
                 # expand dims so ordering is preserved
-                terms["eta"] = terms["eta"].expand_dims(dim={terms["s"].name: terms["s"]}, axis=1)
+                terms["eta"] = terms["eta"].expand_dims(
+                    dim={terms["s"].name: terms["s"]}, axis=1
+                )
                 # z(n,k,j,i) = eta(n,j,i) + (eta(n,j,i) + depth(j,i)) * S(k,j,i)
                 ds.coords[zname] = terms["eta"] + (terms["eta"] + terms["depth"]) * S
 
             elif stdname == "ocean_sigma_coordinate":
                 # expand dims so ordering is preserved
-                terms["eta"] = terms["eta"].expand_dims(dim={terms["sigma"].name: terms["sigma"]}, axis=1)
+                terms["eta"] = terms["eta"].expand_dims(
+                    dim={terms["sigma"].name: terms["sigma"]}, axis=1
+                )
                 # z(n,k,j,i) = eta(n,j,i) + sigma(k)*(depth(j,i)+eta(n,j,i))
-                ds.coords[zname] = terms["eta"] + terms["sigma"] * (terms["depth"]
-                                                                    + terms["eta"])
+                ds.coords[zname] = terms["eta"] + terms["sigma"] * (
+                    terms["depth"] + terms["eta"]
+                )
 
             else:
                 raise NotImplementedError(

--- a/cf_xarray/datasets.py
+++ b/cf_xarray/datasets.py
@@ -28,16 +28,17 @@ pomds["sigma"] = (
      -0.183333, -0.15    , -0.116667, -0.083333, -0.05    , -0.016667],
     # fmt: on
     {
-        'units': 'sigma_level',
-        'long_name': 'Sigma Stretched Vertical Coordinate at Nodes',
-        'positive': 'down',
-        'standard_name': 'ocean_sigma_coordinate',
-        'formula_terms': 'sigma: sigma eta: zeta depth: depth',
-        '_CoordinateTransformType': 'Vertical',
-        '_CoordinateAxisType': 'GeoZ',
-        '_CoordinateZisPositive': 'down',
-        '_CoordinateAxes': 'sigma'
-     })
+        "units": "sigma_level",
+        "long_name": "Sigma Stretched Vertical Coordinate at Nodes",
+        "positive": "down",
+        "standard_name": "ocean_sigma_coordinate",
+        "formula_terms": "sigma: sigma eta: zeta depth: depth",
+        "_CoordinateTransformType": "Vertical",
+        "_CoordinateAxisType": "GeoZ",
+        "_CoordinateZisPositive": "down",
+        "_CoordinateAxes": "sigma",
+    }
+)
 pomds["depth"] = 175.0
 pomds["zeta"] = ("ocean_time", [-0.155356, -0.127435])
 

--- a/cf_xarray/datasets.py
+++ b/cf_xarray/datasets.py
@@ -16,6 +16,32 @@ for variable in ds_no_attrs.variables:
     ds_no_attrs[variable].attrs = {}
 
 
+# POM dataset
+pomds = xr.Dataset()
+pomds["sigma"] = (
+    # fmt: off
+    "sigma",
+    [-0.983333, -0.95    , -0.916667, -0.883333, -0.85    , -0.816667,
+     -0.783333, -0.75    , -0.716667, -0.683333, -0.65    , -0.616667,
+     -0.583333, -0.55    , -0.516667, -0.483333, -0.45    , -0.416667,
+     -0.383333, -0.35    , -0.316667, -0.283333, -0.25    , -0.216667,
+     -0.183333, -0.15    , -0.116667, -0.083333, -0.05    , -0.016667],
+    # fmt: on
+    {
+        'units': 'sigma_level',
+        'long_name': 'Sigma Stretched Vertical Coordinate at Nodes',
+        'positive': 'down',
+        'standard_name': 'ocean_sigma_coordinate',
+        'formula_terms': 'sigma: sigma eta: zeta depth: depth',
+        '_CoordinateTransformType': 'Vertical',
+        '_CoordinateAxisType': 'GeoZ',
+        '_CoordinateZisPositive': 'down',
+        '_CoordinateAxes': 'sigma'
+     })
+pomds["depth"] = 175.0
+pomds["zeta"] = ("ocean_time", [-0.155356, -0.127435])
+
+
 popds = xr.Dataset()
 popds.coords["TLONG"] = (
     ("nlat", "nlon"),

--- a/cf_xarray/datasets.py
+++ b/cf_xarray/datasets.py
@@ -33,10 +33,6 @@ pomds["sigma"] = (
         "positive": "down",
         "standard_name": "ocean_sigma_coordinate",
         "formula_terms": "sigma: sigma eta: zeta depth: depth",
-        "_CoordinateTransformType": "Vertical",
-        "_CoordinateAxisType": "GeoZ",
-        "_CoordinateZisPositive": "down",
-        "_CoordinateAxes": "sigma",
     }
 )
 pomds["depth"] = 175.0

--- a/cf_xarray/tests/test_accessor.py
+++ b/cf_xarray/tests/test_accessor.py
@@ -1030,7 +1030,7 @@ def test_param_vcoord_ocean_s_coord():
         romsds.hc + romsds.h
     )
     expected = romsds.zeta + (romsds.zeta + romsds.h) * Zo_rho
-    romsds.cf.decode_vertical_coords(prefix="z")
+    romsds.cf.decode_vertical_coords(outnames={"s_rho": "z_rho"})
     assert_allclose(
         romsds.z_rho.reset_coords(drop=True), expected.reset_coords(drop=True)
     )
@@ -1039,7 +1039,7 @@ def test_param_vcoord_ocean_s_coord():
     Zo_rho = romsds.hc * (romsds.s_rho - romsds.Cs_r) + romsds.Cs_r * romsds.h
 
     expected = Zo_rho + romsds.zeta * (1 + Zo_rho / romsds.h)
-    romsds.cf.decode_vertical_coords(prefix="z")
+    romsds.cf.decode_vertical_coords(outnames={"s_rho": "z_rho"})
     assert_allclose(
         romsds.z_rho.reset_coords(drop=True), expected.reset_coords(drop=True)
     )

--- a/cf_xarray/tests/test_accessor.py
+++ b/cf_xarray/tests/test_accessor.py
@@ -1044,18 +1044,18 @@ def test_param_vcoord_ocean_s_coord():
         romsds.z_rho.reset_coords(drop=True), expected.reset_coords(drop=True)
     )
 
-    romsds.cf.decode_vertical_coords(prefix="ZZZ")
+    romsds.cf.decode_vertical_coords(outnames={"s_rho": "ZZZ_rho"})
     assert "ZZZ_rho" in romsds.coords
 
     copy = romsds.copy(deep=True)
     del copy["zeta"]
     with pytest.raises(KeyError):
-        copy.cf.decode_vertical_coords()
+        copy.cf.decode_vertical_coords(outnames={"s_rho": "z_rho"})
 
     copy = romsds.copy(deep=True)
     copy.s_rho.attrs["formula_terms"] = "s: s_rho C: Cs_r depth: h depth_c: hc"
     with pytest.raises(KeyError):
-        copy.cf.decode_vertical_coords()
+        copy.cf.decode_vertical_coords(outnames={"s_rho": "z_rho"})
 
 
 def test_param_vcoord_ocean_sigma_coordinate():

--- a/cf_xarray/tests/test_accessor.py
+++ b/cf_xarray/tests/test_accessor.py
@@ -1065,7 +1065,7 @@ def test_param_vcoord_ocean_sigma_coordinate():
 
     copy = pomds.copy(deep=True)
     del copy["zeta"]
-    with pytest.raises(KeyError):
+    with pytest.raises(AssertionError):
         copy.cf.decode_vertical_coords()
 
     with pytest.raises(KeyError):

--- a/cf_xarray/tests/test_accessor.py
+++ b/cf_xarray/tests/test_accessor.py
@@ -1030,17 +1030,16 @@ def test_param_vcoord_ocean_s_coord():
         romsds.hc + romsds.h
     )
     expected = romsds.zeta + (romsds.zeta + romsds.h) * Zo_rho
-    romsds.cf.decode_vertical_coords()
+    romsds.cf.decode_vertical_coords(prefix="z")
     assert_allclose(
         romsds.z_rho.reset_coords(drop=True), expected.reset_coords(drop=True)
     )
 
     romsds.s_rho.attrs["standard_name"] = "ocean_s_coordinate_g1"
     Zo_rho = romsds.hc * (romsds.s_rho - romsds.Cs_r) + romsds.Cs_r * romsds.h
-    # import pdb; pdb.set_trace()
-    romsds["zeta"] = romsds.zeta.expand_dims(dim={"s_rho": romsds.s_rho}, axis=1)
-    expected = romsds.zeta * (1 + Zo_rho / romsds.h) + Zo_rho
-    romsds.cf.decode_vertical_coords()
+
+    expected = Zo_rho + romsds.zeta * (1 + Zo_rho / romsds.h)
+    romsds.cf.decode_vertical_coords(prefix="z")
     assert_allclose(
         romsds.z_rho.reset_coords(drop=True), expected.reset_coords(drop=True)
     )
@@ -1061,7 +1060,7 @@ def test_param_vcoord_ocean_s_coord():
 
 def test_param_vcoord_ocean_sigma_coordinate():
     expected = pomds.zeta + pomds.sigma * (pomds.depth + pomds.zeta)
-    pomds.cf.decode_vertical_coords(zname_in="z")
+    pomds.cf.decode_vertical_coords(outnames={"sigma": "z"})
     assert_allclose(pomds.z.reset_coords(drop=True), expected.reset_coords(drop=True))
 
     copy = pomds.copy(deep=True)

--- a/cf_xarray/tests/test_accessor.py
+++ b/cf_xarray/tests/test_accessor.py
@@ -24,8 +24,8 @@ from ..datasets import (
     forecast,
     mollwds,
     multiple,
-    popds,
     pomds,
+    popds,
     romsds,
     vert,
 )
@@ -1038,7 +1038,7 @@ def test_param_vcoord_ocean_s_coord():
     romsds.s_rho.attrs["standard_name"] = "ocean_s_coordinate_g1"
     Zo_rho = romsds.hc * (romsds.s_rho - romsds.Cs_r) + romsds.Cs_r * romsds.h
     # import pdb; pdb.set_trace()
-    romsds['zeta'] = romsds.zeta.expand_dims(dim={"s_rho": romsds.s_rho}, axis=1)
+    romsds["zeta"] = romsds.zeta.expand_dims(dim={"s_rho": romsds.s_rho}, axis=1)
     expected = romsds.zeta * (1 + Zo_rho / romsds.h) + Zo_rho
     romsds.cf.decode_vertical_coords()
     assert_allclose(
@@ -1062,9 +1062,7 @@ def test_param_vcoord_ocean_s_coord():
 def test_param_vcoord_ocean_sigma_coordinate():
     expected = pomds.zeta + pomds.sigma * (pomds.depth + pomds.zeta)
     pomds.cf.decode_vertical_coords(zname_in="z")
-    assert_allclose(
-        pomds.z.reset_coords(drop=True), expected.reset_coords(drop=True)
-    )
+    assert_allclose(pomds.z.reset_coords(drop=True), expected.reset_coords(drop=True))
 
     copy = pomds.copy(deep=True)
     del copy["zeta"]

--- a/cf_xarray/tests/test_accessor.py
+++ b/cf_xarray/tests/test_accessor.py
@@ -1067,6 +1067,9 @@ def test_param_vcoord_ocean_sigma_coordinate():
     del copy["zeta"]
     with pytest.raises(KeyError):
         copy.cf.decode_vertical_coords()
+        
+    with pytest.raises(KeyError):
+        copy.cf.decode_vertical_coords(outnames={})
 
 
 def test_formula_terms():

--- a/cf_xarray/tests/test_accessor.py
+++ b/cf_xarray/tests/test_accessor.py
@@ -1067,7 +1067,7 @@ def test_param_vcoord_ocean_sigma_coordinate():
     del copy["zeta"]
     with pytest.raises(KeyError):
         copy.cf.decode_vertical_coords()
-        
+
     with pytest.raises(KeyError):
         copy.cf.decode_vertical_coords(outnames={})
 

--- a/doc/parametricz.md
+++ b/doc/parametricz.md
@@ -33,7 +33,7 @@ romsds
 Now we decode the vertical coordinates **in-place**. Note the new `z_rho` variable. `cf_xarray` sees that `s_rho` has a `formula_terms` attribute, looks up the right formula using `s_rho.attrs["standard_name"]` and computes a new vertical coordinate variable.
 
 ```{code-cell}
-romsds.cf.decode_vertical_coords()  # adds new z_rho variable
+romsds.cf.decode_vertical_coords(outnames={'s_rho': 'z_rho'})  # adds new z_rho variable
 romsds.z_rho
 ```
 

--- a/doc/parametricz.md
+++ b/doc/parametricz.md
@@ -21,7 +21,7 @@ xr.set_options(display_expand_data=False)
 
 # Parametric Vertical Coordinates
 
-`cf_xarray` supports decoding [parametric vertical coordinates](http://cfconventions.org/Data/cf-conventions/cf-conventions-1.8/cf-conventions.html#parametric-vertical-coordinate) encoded in the `formula_terms` attribute using {py:meth}`Dataset.cf.decode_vertical_coords`. Right now, only the two ocean s-coordinates are supported, but support for the [rest](http://cfconventions.org/Data/cf-conventions/cf-conventions-1.8/cf-conventions.html#parametric-v-coord) should be easy to add (Pull Requests are very welcome!).
+`cf_xarray` supports decoding [parametric vertical coordinates](http://cfconventions.org/Data/cf-conventions/cf-conventions-1.8/cf-conventions.html#parametric-vertical-coordinate) encoded in the `formula_terms` attribute using {py:meth}`Dataset.cf.decode_vertical_coords`. Right now, only the two ocean s-coordinates and `ocean_sigma_coordinate` are supported, but support for the [rest](http://cfconventions.org/Data/cf-conventions/cf-conventions-1.8/cf-conventions.html#parametric-v-coord) should be easy to add (Pull Requests are very welcome!).
 
 ## Decoding parametric coordinates
 ```{code-cell}

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -3,8 +3,8 @@
 What's New
 ----------
 
-Development since release
-=========================
+v 0.7.1 (unreleased)
+====================
 - added another type of vertical coordinate to decode: ``ocean_sigma_coordinate``. By `Kristen Thyng`_.
 
 

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -2,6 +2,12 @@
 
 What's New
 ----------
+
+Development since release
+=========================
+- added another type of vertical coordinate to decode: ``ocean_sigma_coordinate``. By `Kristen Thyng`_.
+
+
 v0.7.0 (January 24, 2022)
 =========================
 - Many improvements to autoguessing for plotting. By `Deepak Cherian`_


### PR DESCRIPTION
The vertical decoding has been added for `ocean_sigma_coordinate` and the free surface variable has been expanded dimensionally for all the calculations so that the results preserve the standard ordering of time, vertical, lat/Y, lon/X. Three of the tests do not work anymore, though. Expanding dimensionally apparently bumps the attributes off of s_rho, for one. For another, the values are very similar but do not match anymore — not sure why. Interested to see what @dcherian thinks!