### PR TITLE
ENH: Add "Celsius" alias

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Pycharm config
+.idea

--- a/cf_xarray/tests/test_units.py
+++ b/cf_xarray/tests/test_units.py
@@ -73,3 +73,11 @@ def test_udunits_format(units, expected):
     u = ureg.parse_units(units)
 
     assert f"{u:cf}" == expected
+
+
+@pytest.mark.parametrize(
+    "alias",
+    [ureg("Celsius"), ureg("degC"), ureg("C"), ureg("deg_C"), ureg("degrees_Celsius")],
+)
+def test_temperature_aliases(alias):
+    assert alias == ureg("celsius")

--- a/cf_xarray/units.py
+++ b/cf_xarray/units.py
@@ -91,7 +91,7 @@ units.define("@alias meter = gpm")
 units.define("year = 365.25 * day = yr")
 
 # Define commonly encountered units not defined by pint
-units.define("@alias degC = C = deg_C = degrees_Celsius")
+units.define("@alias degC = C = deg_C = Celsius = degrees_Celsius")
 units.define("@alias degK = deg_K")
 units.define("@alias day = d")
 units.define("@alias hour = h")  # Not the Planck constant...


### PR DESCRIPTION
This PR adds "Celsius" as a valid alias for the standard "celsius".
This happens in some instance of E-OBS datasets: https://climexp.knmi.nl/showmetadata.cgi?field=ensembles_025_tg_mo&id=someone@somewhere

It is a backport from xclim units update: https://github.com/Ouranosinc/xclim/pull/1068 as suggest by the maintainer in the dedicated issue.
