### PR TITLE
keep compatibility with the development version of `pint`

### DIFF
--- a/cf_xarray/units.py
+++ b/cf_xarray/units.py
@@ -10,12 +10,6 @@ from pint import (  # noqa: F401
     UnitStrippedWarning,
 )
 
-try:
-    from pint.facets.plain import UnitDefinition, ScaleConverter
-except ImportError:
-    from pint.unit import UnitDefinition
-    from pint.converters import ScaleConverter
-
 # from `xclim`'s unit support module with permission of the maintainers
 try:
 
@@ -83,9 +77,7 @@ units = pint.UnitRegistry(
     force_ndarray_like=True,
 )
 
-units.define(
-    UnitDefinition("percent", "%", (), ScaleConverter(0.01))
-)
+units.define("percent = 0.01 = %")
 
 # Define commonly encountered units (both CF and non-CF) not defined by pint
 units.define("@alias meter = gpm")


### PR DESCRIPTION
- [x] closes #338

Since `pint` is now capable of parsing `%` we don't need the workaround anymore, which allows us to stop using `pint`'s internal API.

I'm not sure about the second failure from #338 (`ValueError: Invalid format specifier`): I can't reproduce that locally.
Edit: that seems to be a race condition, it will only be raised if we execute tests in parallel.