### PR TITLE
Performance improvement: Convert unnecessary (?) deep copies to shallow copies

### DIFF
--- a/cf_xarray/accessor.py
+++ b/cf_xarray/accessor.py
@@ -1797,7 +1797,7 @@ class CFAccessor:
         DataArray or Dataset
             with appropriate attributes added
         """
-        obj = self._obj.copy(deep=True)
+        obj = self._obj.copy(deep=False)
         for var in obj.coords.variables:
             var_is_coord = any(var in val for val in obj.cf.coordinates.values())
             if not var_is_coord and obj[var].ndim == 1 and _is_datetime_like(obj[var]):
@@ -1937,7 +1937,7 @@ class CFAccessor:
         info, table, aliases = parse_cf_standard_name_table(source)
 
         # Loop over standard names
-        ds = self._maybe_to_dataset().copy()
+        ds = self._maybe_to_dataset().copy(deep=False)
         attrs_to_print: dict = {}
         for std_name, var_names in ds.cf.standard_names.items():
 
@@ -2209,7 +2209,7 @@ class CFDatasetAccessor(CFAccessor):
                 apply_mapper(_get_all, self._obj, key, error=False, default=[key])
             )
 
-        obj = self._maybe_to_dataset(self._obj.copy(deep=True))
+        obj = self._maybe_to_dataset(self._obj.copy(deep=False))
 
         bad_vars: set[str] = variables - set(obj.variables)
         if bad_vars:
@@ -2286,7 +2286,7 @@ class CFDatasetAccessor(CFAccessor):
         else:
             coords = keys
 
-        obj = self._maybe_to_dataset(self._obj.copy(deep=True))
+        obj = self._maybe_to_dataset(self._obj.copy(deep=False))
 
         for coord in coords:
             try:

--- a/cf_xarray/datasets.py
+++ b/cf_xarray/datasets.py
@@ -11,7 +11,7 @@ airds.coords["cell_area"] = (
     * 110e3
 )
 
-ds_no_attrs = airds.copy(deep=True)
+ds_no_attrs = airds.copy(deep=False)
 for _variable in ds_no_attrs.variables:
     ds_no_attrs[_variable].attrs = {}
 

--- a/cf_xarray/tests/test_accessor.py
+++ b/cf_xarray/tests/test_accessor.py
@@ -230,7 +230,7 @@ def test_coordinates_quantified():
 
 
 def test_cell_measures():
-    ds = airds.copy(deep=True)
+    ds = airds.copy(deep=False)
     ds["foo"] = xr.DataArray(ds["cell_area"], attrs=dict(standard_name="foo_std_name"))
     ds["air"].attrs["cell_measures"] += " foo_measure: foo"
     assert ("foo_std_name" in ds.cf["air_temperature"].cf) and ("foo_measure" in ds.cf)
@@ -307,7 +307,7 @@ def test_getitem_standard_name():
     expected = airds["lat"]
     assert_identical(actual, expected)
 
-    ds = airds.copy(deep=True)
+    ds = airds.copy(deep=False)
     ds["air2"] = ds.air
     with pytest.raises(KeyError):
         ds.cf["air_temperature"]
@@ -340,11 +340,11 @@ def test_getitem_ancillary_variables():
 
 
 def test_rename_like():
-    original = popds.copy(deep=True)
+    original = popds.copy(deep=False)
 
     # it'll match for axis: X (lon, nlon) and coordinate="longitude" (lon, TLONG)
     # so delete the axis attributes
-    newair = airds.copy(deep=True)
+    newair = airds.copy(deep=False)
     del newair.lon.attrs["axis"]
     del newair.lat.attrs["axis"]
 
@@ -479,7 +479,7 @@ def test_pos_args_methods():
 
 def test_preserve_unused_keys():
 
-    ds = airds.copy(deep=True)
+    ds = airds.copy(deep=False)
     ds.time.attrs.clear()
     actual = ds.cf.sel(X=260, Y=40, time=airds.time[:2], method="nearest")
     expected = ds.sel(lon=260, lat=40, time=airds.time[:2], method="nearest")
@@ -528,7 +528,7 @@ def test_args_methods(obj):
 
 def test_dataarray_getitem():
 
-    air = airds.air.copy()
+    air = airds.air.copy(deep=False)
     air.name = None
 
     assert_identical(air.cf["longitude"], air["lon"])
@@ -543,7 +543,7 @@ def test_dataarray_getitem():
 
 def test_dataarray_plot():
 
-    obj = airds.air.copy(deep=True)
+    obj = airds.air.copy(deep=False)
 
     rv = obj.isel(time=1).transpose("lon", "lat").cf.plot()
     assert isinstance(rv, mpl.collections.QuadMesh)
@@ -636,14 +636,14 @@ def test_getitem(obj, key, expected_key):
 def test_getitem_errors(obj):
     with pytest.raises(KeyError):
         obj.cf["XX"]
-    obj2 = obj.copy(deep=True)
+    obj2 = obj.copy(deep=False)
     obj2.lon.attrs = {}
     with pytest.raises(KeyError):
         obj2.cf["X"]
 
 
 def test_bad_cell_measures_attribute():
-    air2 = airds.copy(deep=True)
+    air2 = airds.copy(deep=False)
     air2.air.attrs["cell_measures"] = "--OPT"
     with pytest.warns(UserWarning):
         air2.cf["air"]
@@ -736,7 +736,7 @@ def test_plot_xincrease_yincrease():
 
 @pytest.mark.parametrize("dims", ["time2", "lat", "time", ["lat", "lon"]])
 def test_add_bounds(dims):
-    obj = airds.copy(deep=True)
+    obj = airds.copy(deep=False)
 
     expected = {}
     expected["lat"] = xr.concat(
@@ -810,7 +810,7 @@ def test_add_bounds_nd_variable():
 
 
 def test_bounds():
-    ds = airds.copy(deep=True).cf.add_bounds("lat")
+    ds = airds.copy(deep=False).cf.add_bounds("lat")
 
     actual = ds.cf.bounds
     expected = {"Y": ["lat_bounds"], "lat": ["lat_bounds"], "latitude": ["lat_bounds"]}
@@ -883,7 +883,7 @@ def test_bounds_to_vertices():
 
 
 def test_get_bounds_dim_name():
-    ds = airds.copy(deep=True).cf.add_bounds("lat")
+    ds = airds.copy(deep=False).cf.add_bounds("lat")
     assert ds.cf.get_bounds_dim_name("latitude") == "bounds"
     assert ds.cf.get_bounds_dim_name("lat") == "bounds"
 
@@ -1015,7 +1015,7 @@ def test_attributes():
     with pytest.raises(AttributeError):
         airds.da.cf.chunks
 
-    airds2 = airds.copy(deep=True)
+    airds2 = airds.copy(deep=False)
     airds2.lon.attrs = {}
     actual = airds2.cf.sizes
     expected = {"lon": 50, "Y": 25, "T": 4, "latitude": 25, "time": 4}
@@ -1046,7 +1046,7 @@ def test_attributes():
     assert_identical(ds1.cf.data_vars["T"], ds1["T"])
 
     # multiple latitudes but only one latitude data_var
-    ds = popds.copy(deep=True)
+    ds = popds.copy(deep=False)
     for var in ["ULAT", "TLAT"]:
         ds[var].attrs["standard_name"] = "latitude"
     ds = ds.reset_coords("ULAT")
@@ -1068,7 +1068,7 @@ def test_Z_vs_vertical_ROMS():
         romsds.z_rho_dummy.reset_coords(drop=True), romsds.temp.cf["vertical"]
     )
 
-    romsds = romsds.copy(deep=True)
+    romsds = romsds.copy(deep=False)
 
     romsds.temp.attrs.clear()
     # look in encoding
@@ -1109,12 +1109,12 @@ def test_param_vcoord_ocean_s_coord():
     romsds.cf.decode_vertical_coords(outnames={"s_rho": "ZZZ_rho"})
     assert "ZZZ_rho" in romsds.coords
 
-    copy = romsds.copy(deep=True)
+    copy = romsds.copy(deep=False)
     del copy["zeta"]
     with pytest.raises(KeyError):
         copy.cf.decode_vertical_coords(outnames={"s_rho": "z_rho"})
 
-    copy = romsds.copy(deep=True)
+    copy = romsds.copy(deep=False)
     copy.s_rho.attrs["formula_terms"] = "s: s_rho C: Cs_r depth: h depth_c: hc"
     with pytest.raises(KeyError):
         copy.cf.decode_vertical_coords(outnames={"s_rho": "z_rho"})
@@ -1125,7 +1125,7 @@ def test_param_vcoord_ocean_sigma_coordinate():
     pomds.cf.decode_vertical_coords(outnames={"sigma": "z"})
     assert_allclose(pomds.z.reset_coords(drop=True), expected.reset_coords(drop=True))
 
-    copy = pomds.copy(deep=True)
+    copy = pomds.copy(deep=False)
     del copy["zeta"]
     with pytest.raises(AssertionError):
         copy.cf.decode_vertical_coords()
@@ -1146,7 +1146,7 @@ def test_formula_terms():
     assert romsds["temp"].cf.formula_terms == srhoterms
     assert romsds["s_rho"].cf.formula_terms == srhoterms
 
-    s_rho = romsds["s_rho"].copy(deep=True)
+    s_rho = romsds["s_rho"].copy(deep=False)
     del s_rho.attrs["standard_name"]
     del s_rho.s_rho.attrs["standard_name"]  # TODO: xarray bug
     assert s_rho.cf.formula_terms == srhoterms
@@ -1617,7 +1617,7 @@ def test_flag_errors():
 def test_missing_variables():
 
     # Bounds
-    ds = mollwds.copy(deep=True)
+    ds = mollwds.copy(deep=False)
     ds = ds.drop_vars("lon_bounds")
     assert ds.cf.bounds == {"lat": ["lat_bounds"], "latitude": ["lat_bounds"]}
 
@@ -1625,12 +1625,12 @@ def test_missing_variables():
         ds.cf.get_bounds("longitude")
 
     # Cell measures
-    ds = airds.copy(deep=True)
+    ds = airds.copy(deep=False)
     ds = ds.drop_vars("cell_area")
     assert ds.cf.cell_measures == {}
 
     # Formula terms
-    ds = vert.copy(deep=True)
+    ds = vert.copy(deep=False)
     ds = ds.drop_vars("ap")
     assert ds.cf.formula_terms == {"lev": {"b": "b", "ps": "ps"}}
 


### PR DESCRIPTION
This converts several (unnecessary?) deep xarray copies to shallow copies throughout tests + `accessor.py`. I was surprised by the quite slow performance of this otherwise lightweight-seeming package and traced the issue to the copy calls.

As far as I can tell, this package only changes attribute dictionaries and adds new data/coordinate variables (i.e., does not touch the numpy arrays underlying each DataArray). If that's correct, `deep=True` should never be required, since both shallow and deep copies copy the various dictionaries associated with each xarray object (i.e. `data_vars`, `coords`, `attrs`, `encoding`). The deep version only differs in that it copies the (possibly enormous) underlying numpy arrays.

Here's a quick demo of "shallow" xarray copies (xarray version `2022.3.0`):

```python
# DataArray attributes within a DataArray copy
da1 = xr.DataArray([1, 2, 3], name='name', attrs={'foo': 'bar'})
da2 = da1.copy(deep=False)
da2.attrs.clear()
print(da1.attrs, da2.attrs)

# DataArray attributes within a Dataset copy
ds1 = da1.to_dataset()
ds2 = ds1.copy(deep=False)
ds2.name.attrs.clear()
print(ds1.name.attrs, ds2.name.attrs)
```

Result (attributes on the old version are unchanged):

```
{'foo': 'bar'} {}
{'foo': 'bar'} {}
```