### PR TITLE
Accounting for NoneType coordinates in attrs/encoding

### DIFF
--- a/cf_xarray/accessor.py
+++ b/cf_xarray/accessor.py
@@ -254,12 +254,10 @@ def _get_axis_coord(obj: DataArray | Dataset, key: str) -> list[str]:
         )
 
     search_in = set()
-    coordinates = obj.encoding.get("coordinates", None)
+    attrs_or_encoding = ChainMap(obj.attrs, obj.encoding)
+    coordinates = attrs_or_encoding.get("coordinates", None)
     # Handles case where the coordinates attribute is None
     # This is used to tell xarray to not write a coordinates attribute
-    if coordinates:
-        search_in.update(coordinates.split(" "))
-    coordinates = obj.attrs.get("coordinates", None)
     if coordinates:
         search_in.update(coordinates.split(" "))
     if not search_in:

--- a/cf_xarray/accessor.py
+++ b/cf_xarray/accessor.py
@@ -254,9 +254,9 @@ def _get_axis_coord(obj: DataArray | Dataset, key: str) -> list[str]:
         )
 
     search_in = set()
-    if "coordinates" in obj.encoding:
+    if "coordinates" in obj.encoding and obj.encoding["coordinates"]:
         search_in.update(obj.encoding["coordinates"].split(" "))
-    if "coordinates" in obj.attrs:
+    if "coordinates" in obj.attrs and obj.attrs["coordinates"]:
         search_in.update(obj.attrs["coordinates"].split(" "))
     if not search_in:
         search_in = set(obj.coords)
@@ -1596,7 +1596,7 @@ class CFAccessor:
         coords: dict[str, list[str]] = {k: [] for k in keys}
         attrs_or_encoding = ChainMap(self._obj[name].attrs, self._obj[name].encoding)
 
-        if "coordinates" in attrs_or_encoding:
+        if "coordinates" in attrs_or_encoding and attrs_or_encoding["coordinates"]:
             coords["coordinates"] = attrs_or_encoding["coordinates"].split(" ")
 
         if "cell_measures" in attrs_or_encoding:

--- a/cf_xarray/accessor.py
+++ b/cf_xarray/accessor.py
@@ -254,10 +254,14 @@ def _get_axis_coord(obj: DataArray | Dataset, key: str) -> list[str]:
         )
 
     search_in = set()
-    if "coordinates" in obj.encoding and obj.encoding["coordinates"]:
-        search_in.update(obj.encoding["coordinates"].split(" "))
-    if "coordinates" in obj.attrs and obj.attrs["coordinates"]:
-        search_in.update(obj.attrs["coordinates"].split(" "))
+    coordinates = obj.encoding.get("coordinates", None)
+    # Handles case where the coordinates attribute is None
+    # This is used to tell xarray to not write a coordinates attribute
+    if coordinates:
+        search_in.update(coordinates.split(" "))
+    coordinates = obj.attrs.get("coordinates", None)
+    if coordinates:
+        search_in.update(coordinates.split(" "))
     if not search_in:
         search_in = set(obj.coords)
 
@@ -1596,8 +1600,11 @@ class CFAccessor:
         coords: dict[str, list[str]] = {k: [] for k in keys}
         attrs_or_encoding = ChainMap(self._obj[name].attrs, self._obj[name].encoding)
 
-        if "coordinates" in attrs_or_encoding and attrs_or_encoding["coordinates"]:
-            coords["coordinates"] = attrs_or_encoding["coordinates"].split(" ")
+        coordinates = attrs_or_encoding.get("coordinates", None)
+        # Handles case where the coordinates attribute is None
+        # This is used to tell xarray to not write a coordinates attribute
+        if coordinates:
+            coords["coordinates"] = coordinates.split(" ")
 
         if "cell_measures" in attrs_or_encoding:
             try:

--- a/cf_xarray/tests/test_accessor.py
+++ b/cf_xarray/tests/test_accessor.py
@@ -298,6 +298,14 @@ def test_accessor_getattr_and_describe():
     assert str(ds_verta.cf) == str(ds_vertb.cf)
 
 
+def test_accessor_getattr_coordinate_Nonetype():
+    ds_vert = vert
+    ds_vert["o3"].encoding["coordinates"] = None
+    assert ds_vert.o3.cf["latitude"].name == "lat"
+    ds_vert["lat"].encoding["coordinates"] = None
+    assert ds_vert.cf["latitude"].name == "lat"
+
+
 def test_getitem_standard_name():
     actual = airds.cf["air_temperature"]
     expected = airds["air"]


### PR DESCRIPTION
With https://github.com/pydata/xarray/pull/5514 it has become practice (at least for me) to occasionally disable the coordinates attribute to be written to file by setting `ds['var'].encoding['coordinates'] = None`. If used too generously, this may however lead to an AttributeError in the cf-xarray accessor:

>        if "coordinates" in obj.encoding:
>           search_in.update(obj.encoding["coordinates"].split(" "))
>E           AttributeError: 'NoneType' object has no attribute 'split'

I suggest this small update to keep that from happening.