### PR TITLE
Fix for shapely 2.0

### DIFF
--- a/cf_xarray/geometry.py
+++ b/cf_xarray/geometry.py
@@ -185,6 +185,8 @@ def points_to_cf(pts: Union[xr.DataArray, Sequence]):
         A Dataset with variables 'x', 'y', 'crd_x', 'crd_y', 'node_count' and 'geometry_container'.
         The coordinates of MultiPoint instances are their first point.
     """
+    from shapely.geometry import MultiPoint
+
     if isinstance(pts, xr.DataArray):
         dim = pts.dims[0]
         coord = pts[dim] if dim in pts.coords else None
@@ -195,7 +197,7 @@ def points_to_cf(pts: Union[xr.DataArray, Sequence]):
 
     x, y, node_count, crdX, crdY = [], [], [], [], []
     for pt in pts:
-        if hasattr(pt, "geoms"):  # MultiPoint
+        if isinstance(pt, MultiPoint):
             xy = np.concatenate([p.coords for p in pt.geoms])
         else:
             xy = np.atleast_2d(pt.coords)

--- a/cf_xarray/geometry.py
+++ b/cf_xarray/geometry.py
@@ -195,7 +195,10 @@ def points_to_cf(pts: Union[xr.DataArray, Sequence]):
 
     x, y, node_count, crdX, crdY = [], [], [], [], []
     for pt in pts:
-        xy = np.atleast_2d(np.array(pt))
+        if hasattr(pt, 'geoms'):  # MultiPoint
+            xy = np.concatenate([p.coords for p in pt.geoms])
+        else:
+            xy = np.atleast_2d(pt.coords)
         x.extend(xy[:, 0])
         y.extend(xy[:, 1])
         node_count.append(xy.shape[0])

--- a/cf_xarray/geometry.py
+++ b/cf_xarray/geometry.py
@@ -195,7 +195,7 @@ def points_to_cf(pts: Union[xr.DataArray, Sequence]):
 
     x, y, node_count, crdX, crdY = [], [], [], [], []
     for pt in pts:
-        if hasattr(pt, 'geoms'):  # MultiPoint
+        if hasattr(pt, "geoms"):  # MultiPoint
             xy = np.concatenate([p.coords for p in pt.geoms])
         else:
             xy = np.atleast_2d(pt.coords)

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -3,6 +3,11 @@
 What's New
 ----------
 
+v0.7.7 (Unreleased)
+===================
+- Fix to ``geometry.points_to_cf`` to support shapely 2.0. (:pr:`386`).
+  By `Pascal Bourgault`_
+
 v0.7.6 (Dec 07, 2022)
 =====================
 


### PR DESCRIPTION
This is a small fix to support  `shapely` 2.0. Changes were made between 1.8 and 2 that removed the implicit array interface the previous  `points_to_cf` was using.  We now need a check for  "MultiPoints", but the change still is minimal.
This works with the previous shapely too.