### PR TITLE
Update link to COSIMA tutorial

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -35,7 +35,7 @@ or using ``conda``
    examples/introduction
    EarthCube 2021 demo <https://earthcube2021.github.io/ec21_book/notebooks/ec21_cherian_etal/DC_01_cf-xarray.html>
    CESM ocean model demo <https://pop-tools.readthedocs.io/en/latest/examples/cesm-cmip-cf-xarray.html>
-   COSIMA ocean-sea ice model demo <https://cosima-recipes.readthedocs.io/en/latest/tutorials/Model_Agnostic_Analysis.html#gallery-tutorials-model-agnostic-analysis-ipynb>
+   COSIMA ocean-sea ice model demo <https://cosima-recipes.readthedocs.io/en/latest/Tutorials/Model_Agnostic_Analysis.html>
 
 .. toctree::
    :maxdepth: 2


### PR DESCRIPTION
After a change in COSIMA-recipes docs `tutorials` -> `Tutorials`

cc @aidanheerdegen, @Angus-g