### PR TITLE
Don't look for `T` in sgrid axes

### DIFF
--- a/cf_xarray/accessor.py
+++ b/cf_xarray/accessor.py
@@ -321,10 +321,9 @@ def _get_axis_coord(obj: DataArray | Dataset, key: str) -> list[str]:
                     if units in expected:
                         results.update((coord,))
 
-    if key in _AXIS_NAMES and "grid_topology" in obj.cf.cf_roles:
+    if key in ["X", "Y", "Z"] and "grid_topology" in obj.cf.cf_roles:
         sgrid_axes = sgrid.parse_axes(obj)
-        if key in sgrid_axes:
-            results.update((search_in | set(obj.dims)) & sgrid_axes[key])
+        results.update((search_in | set(obj.dims)) & sgrid_axes[key])
 
     return list(results)
 

--- a/cf_xarray/accessor.py
+++ b/cf_xarray/accessor.py
@@ -323,7 +323,8 @@ def _get_axis_coord(obj: DataArray | Dataset, key: str) -> list[str]:
 
     if key in _AXIS_NAMES and "grid_topology" in obj.cf.cf_roles:
         sgrid_axes = sgrid.parse_axes(obj)
-        results.update((search_in | set(obj.dims)) & sgrid_axes[key])
+        if key in sgrid_axes:
+            results.update((search_in | set(obj.dims)) & sgrid_axes[key])
 
     return list(results)
 

--- a/cf_xarray/tests/test_accessor.py
+++ b/cf_xarray/tests/test_accessor.py
@@ -1878,12 +1878,14 @@ def test_grid_topology() -> None:
     ds = xr.Dataset(
         data_vars={},
         coords={
+            "time": ("time", [1, 2, 3], {"standard_name": "time"}),
             "mesh": (tuple(), 1, {"cf_role": "mesh_topology"}),
             "grid": (tuple(), 1, {"cf_role": "grid_topology"}),
         },
     )
     assert_identical(ds.cf["grid_topology"], ds.grid.reset_coords(drop=True))
     assert_identical(ds.cf["mesh_topology"], ds.mesh.reset_coords(drop=True))
+    assert "T" in ds.cf.axes
 
 
 @requires_scipy


### PR DESCRIPTION
cf-xarray is not finding T as a time axis due to a KeyError. This first checks to see if the key is in sgrid_axes before using that.

Closes https://github.com/xarray-contrib/cf-xarray/issues/434