### PR TITLE
use trusted publishing

### DIFF
--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -83,6 +83,13 @@ jobs:
     needs: test-built-dist
     if: github.event_name == 'release'
     runs-on: ubuntu-latest
+
+    environment:
+      name: pypi
+      url: https://pypi.org/p/cf-xarray
+    permissions:
+      id-token: write
+
     steps:
       - uses: actions/download-artifact@v3
         with:
@@ -90,6 +97,3 @@ jobs:
           path: dist
       - name: Publish package to PyPI
         uses: pypa/gh-action-pypi-publish@v1.8.5
-        with:
-          password: ${{ secrets.PYPI_PASSWORD }}
-          verbose: true

--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -97,3 +97,5 @@ jobs:
           path: dist
       - name: Publish package to PyPI
         uses: pypa/gh-action-pypi-publish@v1.8.5
+        with:
+          verbose: true


### PR DESCRIPTION
There's a relatively new feature called [trusted publishing](https://docs.pypi.org/trusted-publishers/) on PyPI (based on OpenID Connect) that aims to replace the long-lived API tokens. Github and the action we use to upload to PyPI also [support it](https://github.com/pypa/gh-action-pypi-publish#trusted-publishing).

One main advantage is that this also allows creating *new* PyPI projects, so we don't have to manually upload we a user's API token to create the project, create a restricted API token for the project and use that.

I'm submitting a PR here first before doing the same for `xarray` just to make sure this works just as smoothly for larger projects as for the [little project](https://github.com/umr-lops/xarray-safe-rcm) I just used to try this out.

@dcherian, if this sounds good to you, you (or any other owner of the `cf-xarray` project on PyPI) will have to manually add a pending publisher as described in the PyPI docs linked above, after which the workflow should work as usual.