### PR TITLE
Add handling of cftime bounds

### DIFF
--- a/cf_xarray/helpers.py
+++ b/cf_xarray/helpers.py
@@ -23,6 +23,11 @@ def _guess_bounds_1d(da, dim):
         ADDED_INDEX = True
 
     diff = da.diff(dim)
+    # Here we would need some escape based on a check of whether we were
+    # looking at cftime or not. It's not clear to me whether the fix should be
+    # here or further upstream though (either the casting shouldn't happen or
+    # numpy should be able to handle operations with cftime or we have some odd
+    # use case and need a workaround here).
     lower = da - diff / 2
     upper = da + diff / 2
     bounds = xr.concat([lower, upper], dim="bounds")

--- a/cf_xarray/tests/test_accessor.py
+++ b/cf_xarray/tests/test_accessor.py
@@ -981,7 +981,7 @@ def test_bounds_to_vertices() -> None:
     with pytest.raises(ValueError):
         dsv = dsb.cf.bounds_to_vertices("T")
 
-    # Works on datetime arrays to
+    # Works on datetime arrays too
     dsb = dsb.cf.add_bounds("time")
     dsv = dsb.cf.bounds_to_vertices()
     assert "time_bounds" in dsv

--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -11,7 +11,26 @@
 Contributing
 ------------
 
-This section will be expanded later. For now it lists docstrings for a number of internal variables, classes and functions.
+This section will be expanded later. For now it tells you how to get setup to
+run the tests and lists docstrings for a number of internal variables, classes
+and functions.
+
+Running the tests
+~~~~~~~~~~~~~~~~~
+
+The simplest way is using conda/mamba (same as in the CI). Create yourself a
+conda/mamba environment (e.g. ``mamba create -f ci/environment.yml``).
+Activate your environment. Next install the local version of ``cf-xarray``,
+``python -m pip install --no-deps -e .``. Now you are ready to run the tests
+with ``pytest``.
+
+Pre-commit
+~~~~~~~~~~
+
+If you want the pre-commit hook too, after installing your environment as
+above, simply install pre-commit (``pip install pre-commit``) and then run
+``pre-commit install``. Now each time you commit you'll get the pre-commit
+checks for free.
 
 Variables
 ~~~~~~~~~


### PR DESCRIPTION
At the moment this just adds a failing test that shows that add_bounds fails if the times are cftimes. I'm not sure what the best solution would be.