### PR TITLE
added `ValueError` for missing `grid_mapping` variable

### DIFF
--- a/cf_xarray/accessor.py
+++ b/cf_xarray/accessor.py
@@ -2737,7 +2737,11 @@ class CFDataArrayAccessor(CFAccessor):
         if not grid_mapping:
             raise ValueError("No 'grid_mapping' attribute present.")
 
+        if grid_mapping not in da._coords:
+            raise ValueError(f"Grid Mapping variable {grid_mapping} not present.")
+
         grid_mapping_var = da[grid_mapping]
+
         return grid_mapping_var.attrs["grid_mapping_name"]
 
     def __getitem__(self, key: Hashable | Iterable[Hashable]) -> DataArray:

--- a/cf_xarray/tests/test_accessor.py
+++ b/cf_xarray/tests/test_accessor.py
@@ -1001,6 +1001,17 @@ def test_grid_mappings():
     actual = ds.cf["temp"].cf["rotated_latitude_longitude"]
     assert_identical(actual, expected)
 
+    # not properly propagated if grid mapping variable not in coords
+    with pytest.raises(
+        ValueError, match="Grid Mapping variable rotated_pole not present."
+    ):
+        ds.temp.cf.grid_mapping_name
+
+    # check for https://github.com/xarray-contrib/cf-xarray/issues/448
+    expected = ds.rlon
+    actual = rotds.temp.cf["X"]
+    assert_identical(expected, actual)
+
     # Test repr
     expected = """\
            Grid Mappings:   rotated_latitude_longitude: ['rotated_pole']"""


### PR DESCRIPTION
closes #448 

This implements the fix suggested by @dcherian in #448 