### PR TITLE
Add conversion between cf and shapely for lines

### DIFF
--- a/cf_xarray/geometry.py
+++ b/cf_xarray/geometry.py
@@ -163,8 +163,10 @@ def cf_to_shapely(ds: xr.Dataset):
     geom_type = ds.geometry_container.attrs["geometry_type"]
     if geom_type == "point":
         geometries = cf_to_points(ds)
-    elif geom_type in ["line", "polygon"]:
+    elif geom_type == "line":
         geometries = cf_to_lines(ds)
+    elif geom_type == "polygon":
+        raise NotImplementedError("Polygon geometry conversion is not implemented.")
     else:
         raise ValueError(
             f"Valid CF geometry types are 'point', 'line' and 'polygon'. Got {geom_type}"
@@ -317,7 +319,8 @@ def cf_to_lines(ds: xr.Dataset):
     # Shorthand for convenience
     geo = ds.geometry_container.attrs
 
-    # The features dimension name, defaults to the one of 'node_count' or the dimension of the coordinates, if present.
+    # The features dimension name, defaults to the one of 'part_node_count'
+    # or the dimension of the coordinates, if present.
     feat_dim = None
     if "coordinates" in geo and feat_dim is None:
         xcoord_name, _ = geo["coordinates"].split(" ")

--- a/cf_xarray/geometry.py
+++ b/cf_xarray/geometry.py
@@ -357,7 +357,7 @@ def cf_to_lines(ds: xr.Dataset):
         if indexes.shape == (0, 2):
             geoms[i] = LineString(xy[j : j + n, :])
         else:
-            geoms[i] = MultiLineString([xy[ii[0]: ii[1], :] for ii in indexes])
+            geoms[i] = MultiLineString([xy[ii[0] : ii[1], :] for ii in indexes])
         j += n
 
     return xr.DataArray(geoms, dims=part_node_count.dims, coords=part_node_count.coords)

--- a/cf_xarray/geometry.py
+++ b/cf_xarray/geometry.py
@@ -397,7 +397,7 @@ def cf_to_lines(ds: xr.Dataset):
     # The features dimension name, defaults to the one of 'part_node_count'
     # or the dimension of the coordinates, if present.
     feat_dim = None
-    if "coordinates" in geo and feat_dim is None:
+    if "coordinates" in geo:
         xcoord_name, _ = geo["coordinates"].split(" ")
         (feat_dim,) = ds[xcoord_name].dims
 
@@ -418,7 +418,7 @@ def cf_to_lines(ds: xr.Dataset):
         # No part_node_count means there are no multilines
         # And if we had no coordinates, then the dimension defaults to "index"
         feat_dim = feat_dim or "index"
-        part_node_count = xr.DataArray([1] * xy.shape[0], dims=(feat_dim,))
+        part_node_count = xr.DataArray(node_count.values, dims=(feat_dim,))
         if feat_dim in ds.coords:
             part_node_count = part_node_count.assign_coords({feat_dim: ds[feat_dim]})
 

--- a/cf_xarray/geometry.py
+++ b/cf_xarray/geometry.py
@@ -355,11 +355,14 @@ def cf_to_lines(ds: xr.Dataset):
     # be included in that object.
     maxes = np.cumsum(part_node_count)
     mins = np.insert(maxes[:-1], 0, 0)
-    dummy = np.broadcast_to(np.cumsum(node_count), (len(part_node_count), len(node_count)))
+    dummy = np.broadcast_to(
+        np.cumsum(node_count), (len(part_node_count), len(node_count))
+    )
     is_multi = np.where(
-        (dummy <= np.expand_dims(maxes, axis=1)) & (dummy > np.expand_dims(mins, axis=1)),
+        (dummy <= np.expand_dims(maxes, axis=1))
+        & (dummy > np.expand_dims(mins, axis=1)),
         np.ones_like(dummy),
-        np.zeros_like(dummy)
+        np.zeros_like(dummy),
     )
 
     # create multilinestrings for each set of lines. Note that we create multiline strings
@@ -369,7 +372,9 @@ def cf_to_lines(ds: xr.Dataset):
 
     # construct the final geometry by pulling items from the lines or multilines based on
     # the number of lines that are mapped to each object.
-    _, index, counts = np.unique(multiline_indices, return_counts=True, return_index=True)
+    _, index, counts = np.unique(
+        multiline_indices, return_counts=True, return_index=True
+    )
     geoms = np.where(counts == 1, np.array(lines[index]), multilines)
 
     return xr.DataArray(geoms, dims=part_node_count.dims, coords=part_node_count.coords)

--- a/cf_xarray/geometry.py
+++ b/cf_xarray/geometry.py
@@ -322,7 +322,7 @@ def lines_to_cf(lines: xr.DataArray | Sequence):
         coord = None
         lines_ = np.array(lines)
 
-    _, arr, offsets  = to_ragged_array(lines_)
+    _, arr, offsets = to_ragged_array(lines_)
     x = arr[:, 0]
     y = arr[:, 1]
 

--- a/cf_xarray/tests/test_geometry.py
+++ b/cf_xarray/tests/test_geometry.py
@@ -131,10 +131,15 @@ def test_shapely_to_cf(geometry_ds):
 
 @requires_shapely
 def test_shapely_to_cf_errors():
-    from shapely.geometry import Polygon, Point
+    from shapely.geometry import Point, Polygon
 
-    geoms = [Polygon([[1, 1], [1, 3], [3, 3], [1, 1]]), Polygon([[1, 1, 4], [1, 3, 4], [3, 3, 3], [1, 1, 4]])]
-    with pytest.raises(NotImplementedError, match="Polygon geometry conversion is not implemented"):
+    geoms = [
+        Polygon([[1, 1], [1, 3], [3, 3], [1, 1]]),
+        Polygon([[1, 1, 4], [1, 3, 4], [3, 3, 3], [1, 1, 4]]),
+    ]
+    with pytest.raises(
+        NotImplementedError, match="Polygon geometry conversion is not implemented"
+    ):
         cfxr.shapely_to_cf(geoms)
 
     geoms.append(Point(1, 2))

--- a/cf_xarray/tests/test_geometry.py
+++ b/cf_xarray/tests/test_geometry.py
@@ -51,7 +51,7 @@ def geometry_ds():
 
 @pytest.fixture
 def geometry_line_ds():
-    from shapely.geometry import MultiLineString, LineString
+    from shapely.geometry import LineString, MultiLineString
 
     # empty/fill workaround to avoid numpy deprecation(warning) due to the array interface of shapely geometries.
     geoms = np.empty(3, dtype=object)
@@ -70,8 +70,12 @@ def geometry_line_ds():
     shp_ds = ds.assign(geometry=xr.DataArray(geoms, dims=("index",)))
 
     cf_ds = ds.assign(
-        x=xr.DataArray([0, 1, 4, 5, 0, 1, 1, 1.0, 2.0, 1.7], dims=("node",), attrs={"axis": "X"}),
-        y=xr.DataArray([0, 2, 4, 6, 0, 0, 1, 1.0, 2.0, 9.5], dims=("node",), attrs={"axis": "Y"}),
+        x=xr.DataArray(
+            [0, 1, 4, 5, 0, 1, 1, 1.0, 2.0, 1.7], dims=("node",), attrs={"axis": "X"}
+        ),
+        y=xr.DataArray(
+            [0, 2, 4, 6, 0, 0, 1, 1.0, 2.0, 9.5], dims=("node",), attrs={"axis": "Y"}
+        ),
         part_node_count=xr.DataArray([4, 3, 3], dims=("index",)),
         node_count=xr.DataArray([2, 2, 3, 3], dims=("counter",)),
         crd_x=xr.DataArray([1.0, 3.0, 4.0], dims=("index",), attrs={"nodes": "x"}),

--- a/cf_xarray/tests/test_geometry.py
+++ b/cf_xarray/tests/test_geometry.py
@@ -48,6 +48,7 @@ def geometry_ds():
 
     return cf_ds, shp_ds
 
+
 @pytest.fixture
 def geometry_line_ds():
     from shapely.geometry import LineString, MultiLineString
@@ -89,6 +90,7 @@ def geometry_line_ds():
 
     return cf_ds, shp_da
 
+
 @pytest.fixture
 def geometry_line_without_multilines_ds():
     from shapely.geometry import LineString
@@ -104,12 +106,8 @@ def geometry_line_without_multilines_ds():
     shp_da = xr.DataArray(geoms, dims=("index",), name="geometry")
 
     cf_ds = ds.assign(
-        x=xr.DataArray(
-            [0, 1, 1, 1.0, 2.0, 1.7], dims=("node",), attrs={"axis": "X"}
-        ),
-        y=xr.DataArray(
-            [0, 0, 1, 1.0, 2.0, 9.5], dims=("node",), attrs={"axis": "Y"}
-        ),
+        x=xr.DataArray([0, 1, 1, 1.0, 2.0, 1.7], dims=("node",), attrs={"axis": "X"}),
+        y=xr.DataArray([0, 0, 1, 1.0, 2.0, 9.5], dims=("node",), attrs={"axis": "Y"}),
         node_count=xr.DataArray([3, 3], dims=("segment",)),
         crd_x=xr.DataArray([0.0, 1.0], dims=("index",), attrs={"nodes": "x"}),
         crd_y=xr.DataArray([0.0, 1.0], dims=("index",), attrs={"nodes": "y"}),
@@ -126,7 +124,6 @@ def geometry_line_without_multilines_ds():
     cf_ds = cf_ds.set_coords(["x", "y", "crd_x", "crd_y"])
 
     return cf_ds, shp_da
-
 
 
 @requires_shapely
@@ -187,7 +184,9 @@ def test_shapely_to_cf_for_lines_as_sequence(geometry_line_ds):
 
 
 @requires_shapely
-def test_shapely_to_cf_for_lines_without_multilines(geometry_line_without_multilines_ds):
+def test_shapely_to_cf_for_lines_without_multilines(
+    geometry_line_without_multilines_ds,
+):
     expected, in_da = geometry_line_without_multilines_ds
     actual = cfxr.shapely_to_cf(in_da)
     xr.testing.assert_identical(actual, expected)
@@ -242,7 +241,9 @@ def test_cf_to_shapely_for_lines(geometry_line_ds):
 
 
 @requires_shapely
-def test_cf_to_shapely_for_lines_without_multilines(geometry_line_without_multilines_ds):
+def test_cf_to_shapely_for_lines_without_multilines(
+    geometry_line_without_multilines_ds,
+):
     in_ds, expected = geometry_line_without_multilines_ds
     actual = cfxr.cf_to_shapely(in_ds)
     assert actual.dims == ("index",)
@@ -251,7 +252,9 @@ def test_cf_to_shapely_for_lines_without_multilines(geometry_line_without_multil
     in_ds = in_ds.assign_coords(index=["b", "c"])
     actual = cfxr.cf_to_shapely(in_ds)
     assert actual.dims == ("index",)
-    xr.testing.assert_identical(actual.drop_vars(["crd_x", "crd_y"]), expected.assign_coords(index=["b", "c"]))
+    xr.testing.assert_identical(
+        actual.drop_vars(["crd_x", "crd_y"]), expected.assign_coords(index=["b", "c"])
+    )
 
 
 @requires_shapely

--- a/cf_xarray/tests/test_geometry.py
+++ b/cf_xarray/tests/test_geometry.py
@@ -48,7 +48,6 @@ def geometry_ds():
 
     return cf_ds, shp_ds
 
-
 @pytest.fixture
 def geometry_line_ds():
     from shapely.geometry import LineString, MultiLineString
@@ -90,6 +89,45 @@ def geometry_line_ds():
 
     return cf_ds, shp_da
 
+@pytest.fixture
+def geometry_line_without_multilines_ds():
+    from shapely.geometry import LineString
+
+    # empty/fill workaround to avoid numpy deprecation(warning) due to the array interface of shapely geometries.
+    geoms = np.empty(2, dtype=object)
+    geoms[:] = [
+        LineString([[0, 0], [1, 0], [1, 1]]),
+        LineString([[1.0, 1.0], [2.0, 2.0], [1.7, 9.5]]),
+    ]
+
+    ds = xr.Dataset()
+    shp_da = xr.DataArray(geoms, dims=("index",), name="geometry")
+
+    cf_ds = ds.assign(
+        x=xr.DataArray(
+            [0, 1, 1, 1.0, 2.0, 1.7], dims=("node",), attrs={"axis": "X"}
+        ),
+        y=xr.DataArray(
+            [0, 0, 1, 1.0, 2.0, 9.5], dims=("node",), attrs={"axis": "Y"}
+        ),
+        node_count=xr.DataArray([3, 3], dims=("segment",)),
+        crd_x=xr.DataArray([0.0, 1.0], dims=("index",), attrs={"nodes": "x"}),
+        crd_y=xr.DataArray([0.0, 1.0], dims=("index",), attrs={"nodes": "y"}),
+        geometry_container=xr.DataArray(
+            attrs={
+                "geometry_type": "line",
+                "node_count": "node_count",
+                "node_coordinates": "x y",
+                "coordinates": "crd_x crd_y",
+            }
+        ),
+    )
+
+    cf_ds = cf_ds.set_coords(["x", "y", "crd_x", "crd_y"])
+
+    return cf_ds, shp_da
+
+
 
 @requires_shapely
 def test_shapely_to_cf(geometry_ds):
@@ -127,6 +165,32 @@ def test_shapely_to_cf(geometry_ds):
 
     out = cfxr.shapely_to_cf([Point(2, 3)])
     assert set(out.dims) == {"features", "node"}
+
+
+@requires_shapely
+def test_shapely_to_cf_for_lines_as_da(geometry_line_ds):
+    expected, in_da = geometry_line_ds
+
+    actual = cfxr.shapely_to_cf(in_da)
+    xr.testing.assert_identical(actual, expected)
+
+    in_da = in_da.assign_coords(index=["a", "b", "c"])
+    actual = cfxr.shapely_to_cf(in_da)
+    xr.testing.assert_identical(actual, expected.assign_coords(index=["a", "b", "c"]))
+
+
+@requires_shapely
+def test_shapely_to_cf_for_lines_as_sequence(geometry_line_ds):
+    expected, in_da = geometry_line_ds
+    actual = cfxr.shapely_to_cf(in_da.values)
+    xr.testing.assert_identical(actual, expected)
+
+
+@requires_shapely
+def test_shapely_to_cf_for_lines_without_multilines(geometry_line_without_multilines_ds):
+    expected, in_da = geometry_line_without_multilines_ds
+    actual = cfxr.shapely_to_cf(in_da)
+    xr.testing.assert_identical(actual, expected)
 
 
 @requires_shapely
@@ -169,26 +233,29 @@ def test_cf_to_shapely(geometry_ds):
 
 
 @requires_shapely
-def test_cf_to_shapely_for_line(geometry_line_ds):
+def test_cf_to_shapely_for_lines(geometry_line_ds):
     in_ds, expected = geometry_line_ds
 
     actual = cfxr.cf_to_shapely(in_ds)
     assert actual.dims == ("index",)
-
     xr.testing.assert_identical(actual.drop_vars(["crd_x", "crd_y"]), expected)
 
 
 @requires_shapely
-def test_shapely_to_cf_for_line(geometry_line_ds):
-    expected, in_da = geometry_line_ds
-
-    actual = cfxr.shapely_to_cf(in_da)
-
+def test_cf_to_shapely_for_lines_without_multilines(geometry_line_without_multilines_ds):
+    in_ds, expected = geometry_line_without_multilines_ds
+    actual = cfxr.cf_to_shapely(in_ds)
+    assert actual.dims == ("index",)
     xr.testing.assert_identical(actual, expected)
+
+    in_ds = in_ds.assign_coords(index=["b", "c"])
+    actual = cfxr.cf_to_shapely(in_ds)
+    assert actual.dims == ("index",)
+    xr.testing.assert_identical(actual.drop_vars(["crd_x", "crd_y"]), expected.assign_coords(index=["b", "c"]))
 
 
 @requires_shapely
-def test_cf_to_shapely_errors(geometry_ds):
+def test_cf_to_shapely_errors(geometry_ds, geometry_line_ds):
     in_ds, _ = geometry_ds
     in_ds.geometry_container.attrs["geometry_type"] = "polygon"
     with pytest.raises(NotImplementedError, match="Polygon geometry"):
@@ -196,6 +263,11 @@ def test_cf_to_shapely_errors(geometry_ds):
 
     in_ds.geometry_container.attrs["geometry_type"] = "punkt"
     with pytest.raises(ValueError, match="Valid CF geometry types are "):
+        cfxr.cf_to_shapely(in_ds)
+
+    in_ds, _ = geometry_line_ds
+    del in_ds.geometry_container.attrs["node_count"]
+    with pytest.raises(ValueError, match="'node_count' must be provided"):
         cfxr.cf_to_shapely(in_ds)
 
 

--- a/cf_xarray/tests/test_geometry.py
+++ b/cf_xarray/tests/test_geometry.py
@@ -180,9 +180,9 @@ def test_cf_to_shapely_for_line(geometry_line_ds):
 
 @requires_shapely
 def test_cf_to_shapely_errors(geometry_ds):
-    in_ds, expected = geometry_ds
-    in_ds.geometry_container.attrs["geometry_type"] = "line"
-    with pytest.raises(NotImplementedError, match="Only point geometries conversion"):
+    in_ds, _ = geometry_ds
+    in_ds.geometry_container.attrs["geometry_type"] = "polygon"
+    with pytest.raises(NotImplementedError, match="Polygon geometry"):
         cfxr.cf_to_shapely(in_ds)
 
     in_ds.geometry_container.attrs["geometry_type"] = "punkt"

--- a/cf_xarray/tests/test_geometry.py
+++ b/cf_xarray/tests/test_geometry.py
@@ -49,6 +49,49 @@ def geometry_ds():
     return cf_ds, shp_ds
 
 
+@pytest.fixture
+def geometry_line_ds():
+    from shapely.geometry import MultiLineString, LineString
+
+    # empty/fill workaround to avoid numpy deprecation(warning) due to the array interface of shapely geometries.
+    geoms = np.empty(3, dtype=object)
+    geoms[:] = [
+        MultiLineString([[[0, 0], [1, 2]], [[4, 4], [5, 6]]]),
+        LineString([[0, 0], [1, 0], [1, 1]]),
+        LineString([[1.0, 1.0], [2.0, 2.0], [1.7, 9.5]]),
+    ]
+
+    ds = xr.Dataset(
+        {
+            "data": xr.DataArray(range(len(geoms)), dims=("index",)),
+            "time": xr.DataArray([0, 1, 2], dims=("index",)),
+        }
+    )
+    shp_ds = ds.assign(geometry=xr.DataArray(geoms, dims=("index",)))
+
+    cf_ds = ds.assign(
+        x=xr.DataArray([0, 1, 4, 5, 0, 1, 1, 1.0, 2.0, 1.7], dims=("node",), attrs={"axis": "X"}),
+        y=xr.DataArray([0, 2, 4, 6, 0, 0, 1, 1.0, 2.0, 9.5], dims=("node",), attrs={"axis": "Y"}),
+        part_node_count=xr.DataArray([4, 3, 3], dims=("index",)),
+        node_count=xr.DataArray([2, 2, 3, 3], dims=("counter",)),
+        crd_x=xr.DataArray([1.0, 3.0, 4.0], dims=("index",), attrs={"nodes": "x"}),
+        crd_y=xr.DataArray([2.0, 4.0, 5.0], dims=("index",), attrs={"nodes": "y"}),
+        geometry_container=xr.DataArray(
+            attrs={
+                "geometry_type": "line",
+                "node_count": "node_count",
+                "part_node_count": "part_node_count",
+                "node_coordinates": "x y",
+                "coordinates": "crd_x crd_y",
+            }
+        ),
+    )
+
+    cf_ds = cf_ds.set_coords(["x", "y", "crd_x", "crd_y"])
+
+    return cf_ds, shp_ds
+
+
 @requires_shapely
 def test_shapely_to_cf(geometry_ds):
     from shapely.geometry import Point
@@ -119,6 +162,16 @@ def test_cf_to_shapely(geometry_ds):
     del in_ds.geometry_container.attrs["node_count"]
     out = cfxr.cf_to_shapely(in_ds)
     assert out.dims == ("index",)
+
+
+@requires_shapely
+def test_cf_to_shapely_for_line(geometry_line_ds):
+    in_ds, expected = geometry_line_ds
+
+    actual = cfxr.cf_to_shapely(in_ds)
+    assert actual.dims == ("index",)
+
+    xr.testing.assert_identical(actual.drop_vars(["crd_x", "crd_y"]), expected.geometry)
 
 
 @requires_shapely

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,6 +132,7 @@ module=[
     "pint",
     "matplotlib",
     "pytest",
+    "shapely",
     "shapely.geometry",
     "xarray.core.pycompat",
 ]


### PR DESCRIPTION
I started on this at the SciPy sprints with the idea of pushing forward the work described in this ticket: https://github.com/xarray-contrib/xvec/issues/48. It took me a while to get the logic right :sweat_smile: so I wanted to make sure it was somewhere public in case I don't get a chance to come back to it in the near future.