### PR TITLE
remove distutils

### DIFF
--- a/cf_xarray/tests/__init__.py
+++ b/cf_xarray/tests/__init__.py
@@ -1,7 +1,6 @@
 import importlib
 import re
 from contextlib import contextmanager
-from distutils import version
 
 import dask
 import pytest

--- a/cf_xarray/tests/__init__.py
+++ b/cf_xarray/tests/__init__.py
@@ -4,6 +4,7 @@ from contextlib import contextmanager
 
 import dask
 import pytest
+from packaging import version
 
 
 @contextmanager
@@ -59,7 +60,7 @@ def LooseVersion(vstring):
     # Our development version is something like '0.10.9+aac7bfc'
     # This function just ignored the git commit id.
     vstring = vstring.split("+")[0]
-    return version.LooseVersion(vstring)
+    return version.parse(vstring)
 
 
 has_cftime, requires_cftime = _importorskip("cftime")


### PR DESCRIPTION
It is imported but unused (tests passes without it). Removing this import will make `cf_xarray` ready to Python 3.12.

---
Edit: Changing to packaging.version.parse is not the same thing as `LooseVersion`, see https://discuss.python.org/t/add-looseversion-to-pypa/24359/6,  but we should be OK b/c here b/c the packages checked all follow PEP440.