### PR TITLE
Fix get_bounds_dim_name regression.

### DIFF
--- a/cf_xarray/accessor.py
+++ b/cf_xarray/accessor.py
@@ -2306,11 +2306,15 @@ class CFDatasetAccessor(CFAccessor):
         crd_names = apply_mapper(_get_all, self._obj, key, error=False, default=[key])
 
         variables = self._obj._variables
-        filtered = [crd_name for crd_name in crd_names if "bounds" in variables[crd_name].attrs]
+        filtered = [
+            crd_name for crd_name in crd_names if "bounds" in variables[crd_name].attrs
+        ]
         if len(filtered) > 1:
-            raise KeyError(f"Received multiple matches for {key!r} that have a bounds attribute: {filtered!r} ")
+            raise KeyError(
+                f"Received multiple matches for {key!r} that have a bounds attribute: {filtered!r} "
+            )
 
-        crd_name, = filtered
+        (crd_name,) = filtered
         crd = variables[crd_name]
         crd_attrs = crd._attrs
         if crd_attrs is None or "bounds" not in crd_attrs:

--- a/cf_xarray/accessor.py
+++ b/cf_xarray/accessor.py
@@ -2301,8 +2301,16 @@ class CFDatasetAccessor(CFAccessor):
         -------
         str
         """
-        (crd_name,) = apply_mapper(_get_all, self._obj, key, error=False, default=[key])
+        # In many cases, the bounds variable has the same attrs as the coordinate variable
+        # So multiple matches are possible.
+        crd_names = apply_mapper(_get_all, self._obj, key, error=False, default=[key])
+
         variables = self._obj._variables
+        filtered = [crd_name for crd_name in crd_names if "bounds" in variables[crd_name].attrs]
+        if len(filtered) > 1:
+            raise KeyError(f"Received multiple matches for {key!r} that have a bounds attribute: {filtered!r} ")
+
+        crd_name, = filtered
         crd = variables[crd_name]
         crd_attrs = crd._attrs
         if crd_attrs is None or "bounds" not in crd_attrs:

--- a/cf_xarray/tests/test_accessor.py
+++ b/cf_xarray/tests/test_accessor.py
@@ -969,6 +969,14 @@ def test_get_bounds_dim_name() -> None:
     assert mollwds.cf.get_bounds_dim_name("longitude") == "bounds"
     assert mollwds.cf.get_bounds_dim_name("lon") == "bounds"
 
+    # Be OK with bounds and coordinates having same attributes
+    # GH442
+    assert vert.cf.get_bounds_dim_name("longitude") == "bnds"
+    ds = vert.copy(deep=True)
+    ds.lat.attrs["standard_name"] = "longitude"
+    with pytest.raises(KeyError):
+        ds.cf.get_bounds_dim_name("longitude")
+
 
 def test_grid_mappings():
     ds = rotds.copy(deep=False)


### PR DESCRIPTION
Handle the case where `lat` and `lat_bounds` have same attributes.

Closes #442