### PR TITLE
Add grid_bounds_to_polygons

### DIFF
--- a/cf_xarray/__init__.py
+++ b/cf_xarray/__init__.py
@@ -9,4 +9,7 @@ from .helpers import bounds_to_vertices, vertices_to_bounds  # noqa
 from .options import set_options  # noqa
 from .utils import _get_version
 
+from . import geometry  # noqa
+
+#
 __version__ = _get_version()

--- a/cf_xarray/geometry.py
+++ b/cf_xarray/geometry.py
@@ -293,3 +293,64 @@ def cf_to_points(ds: xr.Dataset):
         j += n
 
     return xr.DataArray(geoms, dims=node_count.dims, coords=node_count.coords)
+
+
+def grid_bounds_to_polygons(ds: xr.Dataset) -> xr.DataArray:
+    """
+    Converts a regular 2D lat/lon grid to a 2D array of shapely polygons.
+
+    Modified from https://notebooksharing.space/view/c6c1f3a7d0c260724115eaa2bf78f3738b275f7f633c1558639e7bbd75b31456.
+
+    Parameters
+    ----------
+    ds : xr.Dataset
+        Dataset with "latitude" and "longitude" variables as well as their bounds variables.
+        1D "latitude" and "longitude" variables are supported. This function will automatically
+        broadcast them against each other.
+
+    Returns
+    -------
+    DataArray
+        DataArray with shapely polygon per grid cell.
+    """
+    from shapely import Polygon
+
+    grid = ds.cf[["latitude", "longitude"]].load().reset_coords()
+    bounds = ds.cf.bounds
+
+    assert "latitude" in bounds
+    assert "longitude" in bounds
+    (lon_bounds,) = bounds["longitude"]
+    (lat_bounds,) = bounds["latitude"]
+
+    (points,) = xr.broadcast(grid)
+
+    bounds_dim = grid.cf.get_bounds_dim_name("latitude")
+    points = points.transpose(..., bounds_dim)
+    assert points.sizes[bounds_dim] == 2
+
+    lonbnd = points[lon_bounds].data
+    latbnd = points[lat_bounds].data
+
+    # geopandas needs this
+    expanded_lon = lonbnd[..., [0, 0, 1, 1]]
+    mask = expanded_lon[..., 0] >= 180
+    expanded_lon[mask, :] = expanded_lon[mask, :] - 360
+
+    # these magic numbers are OK :
+    # - 4 corners to a polygon, and
+    # - 2 from stacking lat, lon along the last axis
+    # flatten here to make iteration easier. It would be nice to avoid that.
+    # potentially with just np.vectorize. The polygon creation is the real slow bit.
+    # Shapely's MultiPolygon also iterates over a list in Python...
+    blocked = np.stack([expanded_lon, latbnd[..., [0, 1, 1, 0]]], axis=-1).reshape(
+        -1, 4, 2
+    )
+    polyarray = np.array(
+        [Polygon(blocked[i, ...]) for i in range(blocked.shape[0])], dtype="O"
+    )
+    newshape = latbnd.shape[:-1]
+    polyarray = polyarray.reshape(newshape)
+    boxes = points[lon_bounds][..., 0].copy(data=polyarray)
+
+    return boxes

--- a/cf_xarray/geometry.py
+++ b/cf_xarray/geometry.py
@@ -440,7 +440,7 @@ def cf_to_lines(ds: xr.Dataset):
     return xr.DataArray(geoms, dims=part_node_count.dims, coords=part_node_count.coords)
 
 
-  def grid_to_polygons(ds: xr.Dataset) -> xr.DataArray:
+def grid_to_polygons(ds: xr.Dataset) -> xr.DataArray:
     """
     Converts a regular 2D lat/lon grid to a 2D array of shapely polygons.
 

--- a/cf_xarray/geometry.py
+++ b/cf_xarray/geometry.py
@@ -957,7 +957,7 @@ def cf_to_polygons(ds: xr.Dataset):
     ).drop_vars(node_count_name)
 
 
-def grid_to_polygons(ds: xr.Dataset) -> xr.DataArray:
+def bounds_to_polygons(ds: xr.Dataset) -> xr.DataArray:
     """
     Converts a regular 2D lat/lon grid to a 2D array of shapely polygons.
 

--- a/cf_xarray/geometry.py
+++ b/cf_xarray/geometry.py
@@ -980,7 +980,7 @@ def bounds_to_polygons(ds: xr.Dataset) -> xr.DataArray:
     grid = ds.cf[["latitude", "longitude"]].load()
     bounds = grid.cf.bounds
     coordinates = grid.cf.coordinates
-    dims = grid.cf.dims
+    dims = tuple(grid.cf.sizes)
     bounds_dim = grid.cf.get_bounds_dim_name("latitude")
 
     if "latitude" in dims or "longitude" in dims:
@@ -999,9 +999,9 @@ def bounds_to_polygons(ds: xr.Dataset) -> xr.DataArray:
         broadcasted = xr.broadcast(
             grid[lon],
             grid[lat],
+        ) + xr.broadcast(
             grid[lon_bounds],
             grid[lat_bounds],
-            exclude=bounds_dim,
         )
         asdict = dict(zip([lon, lat, lon_bounds, lat_bounds], broadcasted))
         # display(asdict)

--- a/cf_xarray/geometry.py
+++ b/cf_xarray/geometry.py
@@ -438,8 +438,8 @@ def cf_to_lines(ds: xr.Dataset):
         geoms = np.where(np.diff(offset2) == 1, lines[offset2[:-1]], multilines)
 
     return xr.DataArray(geoms, dims=part_node_count.dims, coords=part_node_count.coords)
-  
-  
+
+
   def grid_to_polygons(ds: xr.Dataset) -> xr.DataArray:
     """
     Converts a regular 2D lat/lon grid to a 2D array of shapely polygons.

--- a/cf_xarray/geometry.py
+++ b/cf_xarray/geometry.py
@@ -338,16 +338,17 @@ def grid_to_polygons(ds: xr.Dataset) -> xr.DataArray:
     latbnd = points[lat_bounds].data
 
     if points.sizes[bounds_dim] == 2:
-        # geopandas needs this
         lonbnd = lonbnd[..., [0, 0, 1, 1]]
-        mask = lonbnd[..., 0] >= 180
-        lonbnd[mask, :] = lonbnd[mask, :] - 360
         latbnd = latbnd[..., [0, 1, 1, 0]]
 
     elif points.sizes[bounds_dim] != 4:
         raise ValueError(
             f"The size of the detected bounds or vertex dimension {bounds_dim} is not 2 or 4."
         )
+
+    # geopandas needs this
+    mask = lonbnd[..., 0] >= 180
+    lonbnd[mask, :] = lonbnd[mask, :] - 360
 
     polyarray = shapely.polygons(shapely.linearrings(lonbnd, latbnd))
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,7 +132,7 @@ module=[
     "pint",
     "matplotlib",
     "pytest",
-    "shapely.geometry",
+    "shapely.*",
     "xarray.core.pycompat",
 ]
 ignore_missing_imports = true


### PR DESCRIPTION
- [x] Add to api.rst
- [ ] Add test 

This converts "bounds" in the 2-element form to an array of shapely polygons, one per grid cell. A step towards nicely packaging conservative regridding for the ecosystem. It could easily be generalized to the 4-element "vertex" form

Modified from
https://notebooksharing.space/view/c6c1f3a7d0c260724115eaa2bf78f3738b275f7f633c1558639e7bbd75b31456#displayOptions=


cc @martinfleis @benbovy @aulemahal for awareness. I'm not sure if this is at all useful for `xvec` but on the off-chance that it is..