### PR TITLE
Set python-version as string

### DIFF
--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/setup-python@v4
         name: Install Python
         with:
-          python-version: 3.10
+          python-version: "3.10"
 
       - name: Install dependencies
         run: |
@@ -53,7 +53,7 @@ jobs:
       - uses: actions/setup-python@v4
         name: Install Python
         with:
-          python-version: 3.10
+          python-version: "3.10"
       - uses: actions/download-artifact@v3
         with:
           name: releases


### PR DESCRIPTION
The upload action failed recently because the `python-version` was interpreted as a float value. This ensures that it is seen as a string.

The action would need to be re-triggered with these new changes to be used to upload the package to PyPI