### PR TITLE
cast units to `str` before applying any other preprocessor

### DIFF
--- a/cf_xarray/tests/test_units.py
+++ b/cf_xarray/tests/test_units.py
@@ -51,6 +51,13 @@ def test_percent_units():
     assert str(ureg("%").units) == "percent"
 
 
+def test_integer_units():
+    """Test that integer 1 units is equal to dimensionless"""
+    # need to explicitly use parse_units to bypass the runtime type checking
+    # in the quantity constructor
+    assert str(ureg.parse_units(1)) == "dimensionless"
+
+
 @pytest.mark.xfail(reason="not supported by pint, yet: hgrecco/pint#1295")
 def test_udunits_power_syntax():
     """Test that UDUNITS style powers are properly parsed and interpreted."""

--- a/cf_xarray/tests/test_units.py
+++ b/cf_xarray/tests/test_units.py
@@ -58,7 +58,6 @@ def test_integer_units():
     assert str(ureg.parse_units(1)) == "dimensionless"
 
 
-@pytest.mark.xfail(reason="not supported by pint, yet: hgrecco/pint#1295")
 def test_udunits_power_syntax():
     """Test that UDUNITS style powers are properly parsed and interpreted."""
     assert ureg("m2 s-2").units == ureg.m**2 / ureg.s**2

--- a/cf_xarray/units.py
+++ b/cf_xarray/units.py
@@ -77,7 +77,12 @@ units = pint.UnitRegistry(
     ],
     force_ndarray_like=True,
 )
+# ----- end block copied from metpy
 
+# need to insert to make sure this is the first preprocessor
+units.preprocessors.insert(0, str)
+
+# -----
 units.define("percent = 0.01 = %")
 
 # Define commonly encountered units (both CF and non-CF) not defined by pint

--- a/cf_xarray/units.py
+++ b/cf_xarray/units.py
@@ -80,6 +80,7 @@ units = pint.UnitRegistry(
 # ----- end block copied from metpy
 
 # need to insert to make sure this is the first preprocessor
+# This ensures we convert integer `1` to string `"1"`, as needed by pint.
 units.preprocessors.insert(0, str)
 
 # -----


### PR DESCRIPTION
The idea is to accept integer units of `1` for dimensionless, which is explicitly allowed by the CF conventions (we could, however, pass through objects that are not integers unmodified).

Note that `pint` itself doesn't really like the idea of integer units, so this will only work with `ureg.parse_units(1)`: `ureg.Quantity(1, 1)` will raise before any preprocessor is called.

- [x] closes an aspect of jbusecke/xMIP#322