### PR TITLE
ENH: Update units in .cf.differentiate

### DIFF
--- a/cf_xarray/accessor.py
+++ b/cf_xarray/accessor.py
@@ -2102,6 +2102,26 @@ class CFAccessor:
             (_single(_get_coords),), self._obj, coord, error=False, default=[coord]
         )[0]
         result = self._obj.differentiate(coord, *xr_args, **xr_kwargs)
+        if isinstance(self._obj, DataArray):
+            try:
+                result.attrs["units"] = "{:s} / ({:s})".format(
+                    self._obj.attrs["units"], self._obj[coord].attrs["units"]
+                )
+            except KeyError:
+                pass
+        else:
+            try:
+                coord_units = self._obj[coord].attrs["units"]
+            except KeyError:
+                pass
+            else:
+                for name in result.data_vars:
+                    try:
+                        result[name].attrs["units"] = "{:s} / ({:s})".format(
+                            self._obj[name].attrs["units"], coord_units
+                        )
+                    except KeyError:
+                        pass
         if positive_upward:
             coord = self._obj[coord]
             attrs = coord.attrs

--- a/cf_xarray/accessor.py
+++ b/cf_xarray/accessor.py
@@ -959,6 +959,30 @@ def _update_data_units(
         coord_name: str,
         new_unit_template: str
 ) -> DataArray | Dataset:
+    """Update units in result according to template.
+
+    Intended to update units after differentiation or integration, as
+    the quotient or product of the units in source and the units of
+    the coordinate of integration, respectively.
+
+    Parameters
+    ----------
+    result : DataArray | Dataset
+        The data to update
+    source : DataArray | Dataset
+        The data with the units
+    coord_name : str
+        The coordinate with the second unit.  Usually the coordinate
+        of differentiation or integration
+    new_unit_template : str
+        Template for how to combine the units.  Must have two
+        {}-sequences for a format call.
+
+    Returns
+    -------
+    DataArray | Dataset
+        The data with updated units
+    """
     try:
         coord_units = source[coord_name].attrs["units"]
     except KeyError:


### PR DESCRIPTION
Differentiating a field results in a field whose units are the quotient of those of the original field with the units of the field with respect to which the derivative was taken.  This PR adds code to update the units of the derivative to reflect that.

The helper function should simplify adding similar functionality for integrate and cumulative_integrate.

Should I add validation that neither unit is the empty string, since that breaks parsing?