### PR TITLE
Assign new variables by standard names

### DIFF
--- a/cf_xarray/accessor.py
+++ b/cf_xarray/accessor.py
@@ -2662,7 +2662,6 @@ class CFDatasetAccessor(CFAccessor):
 
         # for each standard name and value pair
         for standard_name, values in standard_variables.items():
-
             # default to using existing short name or standard name
             name = getattr(values, "name", standard_name)
 
@@ -2670,8 +2669,9 @@ class CFDatasetAccessor(CFAccessor):
             while name in self._obj.data_vars or name in variables:
                 emit_user_level_warning(
                     f"found existing variable {name}, using {name}_ instead",
-                    UserWarning)
-                name += '_'
+                    UserWarning,
+                )
+                name += "_"
 
             # map name to values (without coords, see #513, xarray#6447)
             values = xr.as_variable(values)


### PR DESCRIPTION
This pull request implements `ds.cf.assign(**standard_variables)`. The new method should:

- [ ] Assign variables by standard name as `**kwargs` or dictionary.
- [ ] Decide on the variable short names without user input (see below).
- [ ] Either handle or reject duplicate standard names (see below).
- [ ] Workaround xarray incompatibilities, currently #513.

Also needed:

- [ ] Add documentation, where should it go?
- [ ] Add tests, including name duplicates.

I would welcome opinions on the two points below.

## 1. Decide about the variable short name

I propose this algorithm:

- If variable has a short name, absent from the dataset, use it.

```python
ds.cf.assign(air_temperature=DataArray(name='tas')) -> 'tas'
```

- Otherwise, use the standard name as a short variable name.

```python
ds.cf.assign(air_temperature=DataArray()) -> 'air_temperature'
```

- If name is already used in dataset, warn user, and add trailing underscores.

```python
ds.cf.assign(
   air_temperature=DataArray(name=tas)).cf.assign(
   total_precipitation=DataArray(name=tas)) -> tas, tas_
```

- If name is taken by another variable in call, also add trailing underscores.

```python
ds.cf.assign(
   air_temperature=DataArray(name=tas),
   total_precipitation=DataArray(name=tas)) -> tas, tas_
```

## 2. When dataset already contains standard name

```python
ds = xr.Dataset()
ds = ds.cf.assign(air_temperature=0)
ds = ds.cf.assign(air_temperature=1)
```

I find it more difficult to decide what the method should do here.

- Override existing variable (same as `Dataset.assign`).
- Override but raise a warning.
- Assign new variable with same standard name.
- Assign new variable but raise a warning.
- Customize via keyword e.g. `existing: ignore, override, raise, warn`

Note: if we allow multiple variables with the same standard name, the resulting Dataset is technically valid, and `ds.cf` shows several variables associated with one standard name, while `ds.cf[standard_name] fails with a `KeyError`.
