### PR TITLE
Cache flag-related objects and refactor extraction of flags

### DIFF
--- a/cf_xarray/accessor.py
+++ b/cf_xarray/accessor.py
@@ -2832,6 +2832,11 @@ class CFDatasetAccessor(CFAccessor):
 
 @xr.register_dataarray_accessor("cf")
 class CFDataArrayAccessor(CFAccessor):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._flags: Dataset | None = None
+
     @property
     def formula_terms(self) -> dict[str, str]:  # numpydoc ignore=SS06
         """
@@ -2977,6 +2982,8 @@ class CFDataArrayAccessor(CFAccessor):
         """
         Dataset containing boolean masks of available flags.
         """
+        if self._flags is not None:
+            return self._flags
         return self._extract_flags()
 
     def _extract_flags(self, flags: Sequence[Hashable] | None = None) -> Dataset:

--- a/cf_xarray/accessor.py
+++ b/cf_xarray/accessor.py
@@ -1167,7 +1167,9 @@ class CFAccessor:
         )
         return dict(zip(flag_meanings, flag_params))
 
-    def _assert_valid_other_comparison(self, other: Hashable) -> Mapping[Hashable, FlagParam]:
+    def _assert_valid_other_comparison(
+        self, other: Hashable
+    ) -> Mapping[Hashable, FlagParam]:
         if other not in self.flag_dict:
             raise ValueError(
                 f"Did not find flag value meaning [{other}] in known flag meanings: [{self.flag_dict.keys()!r}]"

--- a/cf_xarray/formatting.py
+++ b/cf_xarray/formatting.py
@@ -208,10 +208,8 @@ def find_set_bits(mask, value, repeated_masks, bit_length):
 
 
 def _format_flags(accessor, rich):
-    from .accessor import create_flag_dict
-
     try:
-        flag_dict = create_flag_dict(accessor._obj)
+        flag_dict = accessor.flag_dict
     except ValueError:
         return _print_rows(
             "Flag Meanings", ["Invalid Mapping. Check attributes."], rich


### PR DESCRIPTION
The dictionary of flag values/masks is cached in the CFAccessor, moving the code of `create_flag_dict` into a property of the accessor.

The dataset of booleans masks is cached in the CFDataArrayAccessor. I don't know if this is a welcomed change. I would argue that if it is presented as a property (`.flags`), I would expect it to be the same instance on different calls, contrary to a method like `.flags()` or `.get_flags()`. But I'm not very familiar with the rest of the cf-xarray API. Anyway it can be reverted easily.

I have also refactored the construction of that flag dataset to make it (hopefully) more readable and understable. It makes use of the FlagParams named-tuple. The operations on the data are unchanged.