### PR TITLE
add min xarray pin on run and numpy py ver linters

### DIFF
--- a/cf_xarray/accessor.py
+++ b/cf_xarray/accessor.py
@@ -18,7 +18,6 @@ from typing import (
     Any,
     Literal,
     TypeVar,
-    Union,
     cast,
     overload,
 )
@@ -89,7 +88,7 @@ ATTRS["time"] = ATTRS["T"]
 ATTRS["vertical"] = ATTRS["Z"]
 
 # Type for Mapper functions
-Mapper = Callable[[Union[DataArray, Dataset], Hashable], list[Hashable]]
+Mapper = Callable[[DataArray | Dataset, Hashable], list[Hashable]]
 
 # Type for decorators
 F = TypeVar("F", bound=Callable[..., Any])
@@ -1150,9 +1149,10 @@ def create_flag_dict(da) -> Mapping[Hashable, FlagParam]:
         )
 
     flag_params = tuple(
-        FlagParam(mask, value) for mask, value in zip(flag_masks, flag_values)
+        FlagParam(mask, value)
+        for mask, value in zip(flag_masks, flag_values, strict=False)
     )
-    return dict(zip(flag_meanings, flag_params))
+    return dict(zip(flag_meanings, flag_params, strict=False))
 
 
 class CFAccessor:
@@ -3024,7 +3024,7 @@ class CFDataArrayAccessor(CFAccessor):
             x = self._obj.astype("i")
             bit_comp = x & bit_mask
 
-            for i, (flag, value) in enumerate(zip(flags_reduced, values)):
+            for i, (flag, value) in enumerate(zip(flags_reduced, values, strict=False)):
                 bit = bit_comp.isel(_mask=i)
                 if value is not None:
                     out[flag] = bit == value

--- a/cf_xarray/accessor.py
+++ b/cf_xarray/accessor.py
@@ -1368,7 +1368,7 @@ class CFAccessor:
         kwargs: dict[str, Any] | None = None,
     ):
         if coords is not None:
-            if isinstance(coords, (Hashable, DataArray)):
+            if isinstance(coords, Hashable | DataArray):
                 coords_iter: Iterable[Hashable | DataArray] = [coords]
             else:
                 coords_iter = coords

--- a/cf_xarray/coding.py
+++ b/cf_xarray/coding.py
@@ -46,7 +46,7 @@ def encode_multi_index_as_compress(ds, idxnames=None):
     encoded = ds.reset_index(idxnames)
     for idxname in idxnames:
         mindex = ds.indexes[idxname]
-        coords = dict(zip(mindex.names, mindex.levels))
+        coords = dict(zip(mindex.names, mindex.levels, strict=False))
         encoded.update(coords)
         for c in coords:
             encoded[c].attrs = ds[c].attrs
@@ -112,13 +112,16 @@ def decode_compress_to_multi_index(encoded, idxnames=None):
 
             variables = {
                 dim: encoded[dim].isel({dim: xr.Variable(data=index, dims=idxname)})
-                for dim, index in zip(names, indices)
+                for dim, index in zip(names, indices, strict=False)
             }
             decoded = decoded.assign_coords(variables).set_xindex(
                 names, PandasMultiIndex
             )
         except ImportError:
-            arrays = [encoded[dim].data[index] for dim, index in zip(names, indices)]
+            arrays = [
+                encoded[dim].data[index]
+                for dim, index in zip(names, indices, strict=False)
+            ]
             mindex = pd.MultiIndex.from_arrays(arrays, names=names)
             decoded.coords[idxname] = mindex
 

--- a/cf_xarray/formatting.py
+++ b/cf_xarray/formatting.py
@@ -268,14 +268,14 @@ def _format_flags(accessor, rich):
         table.add_column("Value", justify="right")
         table.add_column("Bits", justify="center")
 
-        for val, bit, key in zip(value_text, bit_text, flag_dict):
+        for val, bit, key in zip(value_text, bit_text, flag_dict, strict=False):
             table.add_row(_format_cf_name(key, rich), val, bit)
 
         return table
 
     else:
         rows = []
-        for val, bit, key in zip(value_text, bit_text, flag_dict):
+        for val, bit, key in zip(value_text, bit_text, flag_dict, strict=False):
             rows.append(
                 f"{TAB}{_format_cf_name(key, rich):>{key_width}}: {TAB} {val} {bit}"
             )

--- a/cf_xarray/scripts/make_doc.py
+++ b/cf_xarray/scripts/make_doc.py
@@ -36,7 +36,9 @@ def make_criteria_csv():
     df.transpose().to_csv(os.path.join(csv_dir, "all_criteria.csv"))
 
     # Axes and coordinates
-    for keys, name in zip([_AXIS_NAMES, _COORD_NAMES], ["axes", "coords"]):
+    for keys, name in zip(
+        [_AXIS_NAMES, _COORD_NAMES], ["axes", "coords"], strict=False
+    ):
         subdf = df[sorted(keys)].dropna(axis=1, how="all")
         subdf = subdf.dropna(axis=1, how="all").transpose()
         subdf.transpose().to_csv(os.path.join(csv_dir, f"{name}_criteria.csv"))

--- a/cf_xarray/sgrid.py
+++ b/cf_xarray/sgrid.py
@@ -24,13 +24,14 @@ def parse_axes(ds):
         zip(
             axes_names,
             ({k} for k in grid.attrs["node_dimensions"].split(" ")),
+            strict=False,
         )
     )
     for attr in SGRID_DIM_ATTRS:
         if attr in grid.attrs:
             matches = re.findall(pattern, grid.attrs[attr] + "\n")
             assert len(matches) == ndim, matches
-            for ax, match in zip(axes_names, matches):
+            for ax, match in zip(axes_names, matches, strict=False):
                 axes[ax].update(set(match[:2]))
 
     if ndim == 2 and "vertical_dimensions" in grid.attrs:

--- a/cf_xarray/tests/test_accessor.py
+++ b/cf_xarray/tests/test_accessor.py
@@ -1544,7 +1544,7 @@ def test_groupby_special_ops() -> None:
     grouped = airds.groupby_bins("lat", np.arange(20, 50, 10))
 
     # __iter__
-    for (label, group), (cflabel, cfgroup) in zip(grouped, cfgrouped):
+    for (label, group), (cflabel, cfgroup) in zip(grouped, cfgrouped, strict=False):
         assert label == cflabel
         assert_identical(group, cfgroup)
 

--- a/cf_xarray/utils.py
+++ b/cf_xarray/utils.py
@@ -81,7 +81,9 @@ def parse_cell_methods_attr(attr: str) -> dict[str, str]:
     if len(strings) % 2 != 0:
         raise ValueError(f"attrs['cell_measures'] = {attr!r} is malformed.")
 
-    return dict(zip(strings[slice(0, None, 2)], strings[slice(1, None, 2)]))
+    return dict(
+        zip(strings[slice(0, None, 2)], strings[slice(1, None, 2)], strict=False)
+    )
 
 
 def invert_mappings(*mappings):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
-    "xarray",
+    "xarray>=2022.03.0",
 ]
 dynamic = ["version"]
 
@@ -54,10 +54,10 @@ write_to_template= '__version__ = "{version}"'
 tag_regex= "^(?P<prefix>v)?(?P<version>[^\\+]+)(?P<suffix>.*)?$"
 
 [tool.black]
-target-version = ["py39"]
+target-version = ["py310"]
 
 [tool.ruff]
-target-version = "py39"
+target-version = "py310"
 builtins = ["ellipsis"]
 exclude = [
     ".eggs",


### PR DESCRIPTION
@dcherian feel free to close this b/c it may not fit your ideas. I thought it was odd that a min pin is necessary to build cf_xarray but not to run. That can lead to slower solves and, if there is a `xarray>=2022.03.0` feature necessary at run time, one can create a broken environment the way it is. 

I also bumped the linters to use the min support Python version. However, I'm pretty sure ruff reads `requires-python` if you omit those, reducing the amount of things to remember to edit at every version bump.