### PR TITLE
Raise ValueError in `_get_ordered_vertices()` with "mixed" order

### DIFF
--- a/cf_xarray/helpers.py
+++ b/cf_xarray/helpers.py
@@ -338,6 +338,12 @@ def _get_ordered_vertices(
         elif order == "descending":
             endpoints = np.maximum(bounds[..., :, 0], bounds[..., :, 1])
             last_endpoint = np.minimum(bounds[..., -1, 0], bounds[..., -1, 1])
+        elif order == "mixed":
+            raise ValueError(
+                "Cannot determine vertices for non-monotonic bounds with mixed core "
+                "dimension orders. Try normalizing the coordinates to a monotonic "
+                "convention and try again."
+            )
 
         vertices = np.concatenate(
             [endpoints, np.expand_dims(last_endpoint, axis=-1)], axis=-1


### PR DESCRIPTION
A user reported an issue in #594 where `_get_ordered_vertices` fails to set the `endpoints` variable when the order of core dims are `"mixed"`. In their case, the longitude coordinates are circular (0–360), and the 1-D core dimension isn’t strictly monotonic because it crosses the seam at 0°.

We should raise a `ValueError` for `"mixed"` cases, rather than silently normalize the coordinates. 

- Closes #594 

## Long-term solution
Longer term, somebody can open a PR to consider opt-in support for circular axes, e.g. `bounds_to_vertices(..., circular_period=360.0, start=None)`. With `circular_period` set, cf-xarray could detect circular monotonicity, rotate away from the seam, and proceed safely. 

