### PR TITLE
Avoid DataArray construction when scanning for cell_measures

### DIFF
--- a/cf_xarray/accessor.py
+++ b/cf_xarray/accessor.py
@@ -2107,17 +2107,14 @@ class CFAccessor:
         """
 
         obj = self._obj
-        all_attrs = [
-            ChainMap(da.attrs, da.encoding).get("cell_measures", "")
-            for da in obj.coords.values()
-        ]
         if isinstance(obj, DataArray):
-            all_attrs += [ChainMap(obj.attrs, obj.encoding).get("cell_measures", "")]
-        elif isinstance(obj, Dataset):
-            all_attrs += [
-                ChainMap(da.attrs, da.encoding).get("cell_measures", "")
-                for da in obj.data_vars.values()
-            ]
+            variables = [*obj.coords.variables.values(), obj.variable]
+        else:
+            variables = list(obj.variables.values())
+        all_attrs = [
+            ChainMap(var.attrs, var.encoding).get("cell_measures", "")
+            for var in variables
+        ]
         as_dataset = self._maybe_to_dataset().reset_coords()
 
         keys: dict[str, str] = {}


### PR DESCRIPTION
## Summary

`CFAccessor.cell_measures` scans every variable's `cell_measures` attribute by iterating `obj.coords.values()` and `obj.data_vars.values()`:

```python
all_attrs = [
    ChainMap(da.attrs, da.encoding).get("cell_measures", "")
    for da in obj.coords.values()
]
...
all_attrs += [
    ChainMap(da.attrs, da.encoding).get("cell_measures", "")
    for da in obj.data_vars.values()
]
```

Iterating those mappings constructs a full `DataArray` (resolving its coordinates) **per variable** just to read one attribute. Because `cell_measures` is reached from `__getitem__` → `_get_all_cell_measures`, anything that does `ds.cf[[var]]` pays an O(nvars) DataArray-construction cost, and code that loops over variables calling `ds.cf[[var]]` (e.g. grid/style probing) ends up O(nvars²).

A downstream profile of a metadata endpoint over a many-variable dataset showed this `cell_measures` attr-scan as a top contributor to `Dataset._construct_dataarray` time:

```
ds.cf[[var]] → _getitem → _get_all_cell_measures → cell_measures
  → for da in obj.data_vars.values()  →  _construct_dataarray  (per variable)
```

## Change

Read the `cell_measures` attribute off the bare `Variable` objects (`obj.variables` for a `Dataset`; `obj.coords.variables` + `obj.variable` for a `DataArray`), which carry `.attrs`/`.encoding` without constructing a `DataArray`. This mirrors how `standard_names` already reads from `self._obj._variables`.

Behavior is unchanged (verified against `airds` for both the `Dataset` and `DataArray` paths). Full `test_accessor.py` passes (208 passed, 1 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)